### PR TITLE
feat: add Connect client and Go CI workflows

### DIFF
--- a/.github/release-drafter-config.yml
+++ b/.github/release-drafter-config.yml
@@ -1,0 +1,59 @@
+name-template: "v$RESOLVED_VERSION"
+tag-template: "v$RESOLVED_VERSION"
+categories:
+  - title: "🚀 Features"
+    labels:
+      - "feat"
+      - "feature"
+      - "enhancement"
+  - title: "🐛 Bug Fixes"
+    labels:
+      - "fix"
+      - "bugfix"
+      - "bug"
+  - title: "🧰 Maintenance"
+    labels:
+      - "chore"
+  - title: "💥 Breaking Changes"
+    labels:
+      - "breaking"
+
+change-template: "- $TITLE @$AUTHOR (#$NUMBER)"
+change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
+version-resolver:
+  major:
+    labels:
+      - "major"
+      - "breaking"
+  minor:
+    labels:
+      - "minor"
+  patch:
+    labels:
+      - "patch"
+  default: patch
+template: |
+  ## Changes
+
+  $CHANGES
+
+autolabeler:
+  - label: "chore"
+    files:
+      - "*.md"
+    title:
+      - "/^docs!?:/i"
+      - "/^test!?:/i"
+      - "/^chore!?:/i"
+      - "/^refactor!?:/i"
+  - label: "bug"
+    title:
+      - "/^fix!?:/i"
+      - "/^revert!?:/i"
+  - label: "feature"
+    title:
+      - "/^feat!?:/i"
+      - "/^add!?:/i"
+  - label: "breaking"
+    title:
+      - "/^[a-zA-Z]+!:/i"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: ci
+on:
+  pull_request:
+
+jobs:
+  lint:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - name: Install golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          args: --timeout=5m
+
+  test:
+    name: test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install just
+        uses: taiki-e/install-action@just
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - name: Build and run tests with race detector enabled
+        run: just test-race

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -1,0 +1,27 @@
+name: govulncheck
+on:
+  pull_request:
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  govulncheck:
+    name: govulncheck
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - name: Install dependencies
+        run: |
+          go mod download
+      - id: govulncheck
+        uses: golang/govulncheck-action@v1
+        with:
+          go-package: ./...
+          repo-checkout: false
+          go-version-file: go.mod
+          go-version-input: ""

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,22 @@
+name: Release Drafter
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [opened, reopened, synchronize]
+permissions:
+  contents: read
+jobs:
+  update_release_draft:
+    permissions:
+      contents: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v6
+        with:
+          config-name: release-drafter-config.yml
+          publish: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Justfile
+++ b/Justfile
@@ -19,8 +19,18 @@ ensure-protoc-gen-go:
 fmt:
     buf format -w --path proto
 
-lint:
+buf-lint:
     buf lint --path proto
 
 proto-gen: ensure-protoc-gen-go
     buf generate --path ./proto
+
+test *args:
+    go run gotest.tools/gotestsum@latest --format github-actions ./... {{args}}
+
+test-race: (test "--" "-race")
+
+go-lint *args:
+    golangci-lint run --show-stats {{args}}
+
+lint *args: buf-lint (go-lint args)

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 [![Buf CI](https://github.com/cofide/cofide-api-sdk/workflows/buf-ci/badge.svg)](https://github.com/cofide/cofide-api-sdk/actions?query=workflow%3Abuf-ci+branch%3Amain)
 
-This repository contains the service definitions and code generated stubs for [Cofide's](https://www.cofide.io/) APIs, used for open source projects (e.g. [`cofidectl`](https://github.com/cofide/cofidectl)) and the Cofide product.
-
+This repository contains the service definitions and code generated stubs for [Cofide's](https://www.cofide.io/) APIs, used for open source projects (e.g. [`cofidectl`](https://github.com/cofide/cofidectl)) and the Cofide Connect product.
 Services and messages are defined using Protocol Buffers (protobuf).
+This repository also contains a Go client implementation for the Cofide Connect API.
 
 ## Prerequisites
 
@@ -23,10 +23,12 @@ For convenience, a set of useful commands have been added to the *Justfile* in t
 Some of the key commands include:
 
 - `just fmt` - Formats the protobuf definitions
-- `just lint` - Lints the protobuf definitions in accordance with best practices
+- `just lint` - Lints the protobuf definitions and Go source code in accordance with best practices
 - `just proto-gen` - Generates the code stubs from the protobuf definitions using the defined plugins (specified in *buf.gen.yaml*)
+- `just test` - Runs Go unit tests
 
 The `.proto` files are in the `proto` directory, and the generated stubs for Go are in the `gen/proto/go` directory.
+The Cofide Connect API client is in the `pkg/connect/client` directory.
 
 ## Stability
 

--- a/go.mod
+++ b/go.mod
@@ -1,18 +1,22 @@
 module github.com/cofide/cofide-api-sdk
 
-go 1.22.7
+go 1.23.0
 
-toolchain go1.22.9
+toolchain go1.23.6
 
 require (
 	github.com/spiffe/spire-api-sdk v1.11.2
+	github.com/stretchr/testify v1.10.0
 	google.golang.org/grpc v1.71.0
 	google.golang.org/protobuf v1.36.5
 )
 
 require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	golang.org/x/net v0.34.0 // indirect
 	golang.org/x/sys v0.29.0 // indirect
 	golang.org/x/text v0.21.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250115164207-1a7da9e5054f // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,8 @@ github.com/cncf/xds/go v0.0.0-20210922020428-25de7278fc84/go.mod h1:eXthEFrGJvWH
 github.com/cncf/xds/go v0.0.0-20211001041855-01bcc9b48dfe/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
@@ -53,6 +55,7 @@ github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
@@ -61,6 +64,8 @@ github.com/spiffe/spire-api-sdk v1.11.2/go.mod h1:4uuhFlN6KBWjACRP3xXwrOTNnvaLp1
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
+github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 go.opentelemetry.io/auto/sdk v1.1.0 h1:cH53jehLUN6UFLY71z+NDOiNJqDdPRaXzTel0sJySYA=
 go.opentelemetry.io/auto/sdk v1.1.0/go.mod h1:3wSPjt5PWp2RhlCcmmOial7AvC4DQqZb7a7wCow3W8A=
 go.opentelemetry.io/otel v1.34.0 h1:zRLXxLCgL1WyKsPVrgbSdMN4c0FMkDAskSTQP+0hdUY=
@@ -147,9 +152,12 @@ google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQ
 google.golang.org/protobuf v1.28.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 google.golang.org/protobuf v1.36.5 h1:tPhr+woSbjfYvY6/GPufUoYizxw1cF/yFoxJ2fmpwlM=
 google.golang.org/protobuf v1.36.5/go.mod h1:9fA7Ob0pmnwhb644+1+CVWFRbNajQ6iRojtC/QF5bRE=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.3/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/pkg/connect/client/agent/v1alpha1/agent.go
+++ b/pkg/connect/client/agent/v1alpha1/agent.go
@@ -1,0 +1,129 @@
+// Copyright 2025 Cofide Limited.
+// SPDX-License-Identifier: Apache-2.0
+
+package v1alpha1
+
+import (
+	"context"
+
+	agentpb "github.com/cofide/cofide-api-sdk/gen/go/proto/agent/v1alpha1"
+	agentsvcpb "github.com/cofide/cofide-api-sdk/gen/go/proto/connect/agent_service/v1alpha1"
+	federatedservicepb "github.com/cofide/cofide-api-sdk/gen/go/proto/federated_service/v1alpha1"
+	"github.com/spiffe/spire-api-sdk/proto/spire/api/types"
+	"google.golang.org/grpc"
+)
+
+// AgentClient is an interface for a gRPC client for the v1alpha1 version of the Connect AgentService.
+type AgentClient interface {
+	CreateAgentJoinToken(ctx context.Context, clusterID, trustZoneID string) (string, error)
+	UpdateTrustZoneBundle(ctx context.Context, bundle *types.Bundle) error
+	UpdateManagedTrustZoneBundle(ctx context.Context, trustZoneID string, bundle *types.Bundle) error
+	UpdateAgentStatus(ctx context.Context, status *agentpb.AgentStatus) error
+	// DEPRECATED: Federated services will move to a separate client.
+	RegisterFederatedService(ctx context.Context, fs *federatedservicepb.FederatedService) (string, error)
+	DeregisterFederatedService(ctx context.Context, federatedServiceID string) error
+	GetFederatedService(ctx context.Context, federatedServiceID string) (*federatedservicepb.FederatedService, error)
+	UpdateFederatedService(ctx context.Context, fs *federatedservicepb.FederatedService) error
+	ListFederatedServices(ctx context.Context) ([]*federatedservicepb.FederatedService, error)
+}
+
+type agentClient struct {
+	client agentsvcpb.AgentServiceClient
+}
+
+// New instantiates a new AgentClient for communication with a Connect API.
+func New(conn grpc.ClientConnInterface) AgentClient {
+	return &agentClient{
+		client: agentsvcpb.NewAgentServiceClient(conn),
+	}
+}
+
+func (c *agentClient) CreateAgentJoinToken(ctx context.Context, clusterID, trustZoneID string) (string, error) {
+	resp, err := c.client.CreateAgentJoinToken(ctx, &agentsvcpb.CreateAgentJoinTokenRequest{
+		ClusterId:   &clusterID,
+		TrustZoneId: &trustZoneID,
+	})
+	if err != nil {
+		return "", err
+	}
+	return resp.GetAgentToken(), nil
+}
+
+func (c *agentClient) UpdateTrustZoneBundle(ctx context.Context, bundle *types.Bundle) error {
+	trustzoneBundleUpdateRequest := &agentsvcpb.UpdateTrustZoneBundleRequest{
+		Bundle: bundle,
+	}
+	return c.doUpdateTrustZoneBundle(ctx, trustzoneBundleUpdateRequest)
+}
+
+func (c *agentClient) UpdateManagedTrustZoneBundle(ctx context.Context, trustZoneID string, bundle *types.Bundle) error {
+	trustzoneBundleUpdateRequest := &agentsvcpb.UpdateTrustZoneBundleRequest{
+		Bundle:      bundle,
+		TrustZoneId: trustZoneID,
+	}
+	return c.doUpdateTrustZoneBundle(ctx, trustzoneBundleUpdateRequest)
+}
+
+func (c *agentClient) doUpdateTrustZoneBundle(ctx context.Context, req *agentsvcpb.UpdateTrustZoneBundleRequest) error {
+	_, err := c.client.UpdateTrustZoneBundle(ctx, req)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *agentClient) UpdateAgentStatus(ctx context.Context, status *agentpb.AgentStatus) error {
+	_, err := c.client.UpdateAgentStatus(ctx, &agentsvcpb.UpdateAgentStatusRequest{Status: status})
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *agentClient) RegisterFederatedService(ctx context.Context, fs *federatedservicepb.FederatedService) (string, error) {
+	resp, err := c.client.RegisterFederatedService(ctx, &agentsvcpb.RegisterFederatedServiceRequest{
+		Service: fs,
+	})
+	if err != nil {
+		return "", err
+	}
+	return resp.ServiceId, nil
+}
+
+func (c *agentClient) DeregisterFederatedService(ctx context.Context, federatedServiceID string) error {
+	_, err := c.client.DeregisterFederatedService(ctx, &agentsvcpb.DeregisterFederatedServiceRequest{
+		ServiceId: federatedServiceID,
+	})
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *agentClient) GetFederatedService(ctx context.Context, federatedServiceID string) (*federatedservicepb.FederatedService, error) {
+	resp, err := c.client.GetFederatedService(ctx, &agentsvcpb.GetFederatedServiceRequest{
+		ServiceId: federatedServiceID,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return resp.Service, nil
+}
+
+func (c *agentClient) UpdateFederatedService(ctx context.Context, fs *federatedservicepb.FederatedService) error {
+	_, err := c.client.UpdateFederatedService(ctx, &agentsvcpb.UpdateFederatedServiceRequest{
+		Service: fs,
+	})
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *agentClient) ListFederatedServices(ctx context.Context) ([]*federatedservicepb.FederatedService, error) {
+	resp, err := c.client.ListFederatedServices(ctx, &agentsvcpb.ListFederatedServicesRequest{})
+	if err != nil {
+		return nil, err
+	}
+	return resp.Services, nil
+}

--- a/pkg/connect/client/agent/v1alpha1/agent.go
+++ b/pkg/connect/client/agent/v1alpha1/agent.go
@@ -50,18 +50,18 @@ func (c *agentClient) CreateAgentJoinToken(ctx context.Context, clusterID, trust
 }
 
 func (c *agentClient) UpdateTrustZoneBundle(ctx context.Context, bundle *types.Bundle) error {
-	trustzoneBundleUpdateRequest := &agentsvcpb.UpdateTrustZoneBundleRequest{
+	trustZoneBundleUpdateRequest := &agentsvcpb.UpdateTrustZoneBundleRequest{
 		Bundle: bundle,
 	}
-	return c.doUpdateTrustZoneBundle(ctx, trustzoneBundleUpdateRequest)
+	return c.doUpdateTrustZoneBundle(ctx, trustZoneBundleUpdateRequest)
 }
 
 func (c *agentClient) UpdateManagedTrustZoneBundle(ctx context.Context, trustZoneID string, bundle *types.Bundle) error {
-	trustzoneBundleUpdateRequest := &agentsvcpb.UpdateTrustZoneBundleRequest{
+	trustZoneBundleUpdateRequest := &agentsvcpb.UpdateTrustZoneBundleRequest{
 		Bundle:      bundle,
 		TrustZoneId: trustZoneID,
 	}
-	return c.doUpdateTrustZoneBundle(ctx, trustzoneBundleUpdateRequest)
+	return c.doUpdateTrustZoneBundle(ctx, trustZoneBundleUpdateRequest)
 }
 
 func (c *agentClient) doUpdateTrustZoneBundle(ctx context.Context, req *agentsvcpb.UpdateTrustZoneBundleRequest) error {

--- a/pkg/connect/client/agent/v1alpha1/agent_test.go
+++ b/pkg/connect/client/agent/v1alpha1/agent_test.go
@@ -1,0 +1,169 @@
+// Copyright 2025 Cofide Limited.
+// SPDX-License-Identifier: Apache-2.0
+
+package v1alpha1
+
+import (
+	"context"
+	"testing"
+
+	agentpb "github.com/cofide/cofide-api-sdk/gen/go/proto/agent/v1alpha1"
+	agentsvcpb "github.com/cofide/cofide-api-sdk/gen/go/proto/connect/agent_service/v1alpha1"
+	federatedservicepb "github.com/cofide/cofide-api-sdk/gen/go/proto/federated_service/v1alpha1"
+	"github.com/cofide/cofide-api-sdk/pkg/connect/client/test"
+	"github.com/spiffe/spire-api-sdk/proto/spire/api/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	fakeClusterID   = "fake-cluster-id"
+	fakeTrustZoneID = "fake-tz-id"
+	fakeAgentToken  = "fake-agent-token"
+	fakeTrustDomain = "fake.trust.domain"
+	fakeFSID        = "fake-fs-id"
+	fakeFSName      = "fake-fs-name"
+)
+
+// TestAgentClient_Unimplemented tests AgentClient against an unimplemented server.
+// This ensures that all errors returned are not wrapped can be converted to a gRPC Status using Status.Convert.
+func TestAgentClient_Unimplemented(t *testing.T) {
+	server := test.NewTestServer(t)
+	agentsvcpb.RegisterAgentServiceServer(server.Server, &agentsvcpb.UnimplementedAgentServiceServer{})
+	server.Serve()
+
+	conn := server.CreateClientConn()
+	client := New(conn)
+	ctx := context.Background()
+
+	token, err := client.CreateAgentJoinToken(ctx, "", "")
+	test.RequireUnimplemented(t, err)
+	assert.Empty(t, token)
+
+	err = client.UpdateTrustZoneBundle(ctx, nil)
+	test.RequireUnimplemented(t, err)
+
+	err = client.UpdateManagedTrustZoneBundle(ctx, "", nil)
+	test.RequireUnimplemented(t, err)
+
+	err = client.UpdateAgentStatus(ctx, nil)
+	test.RequireUnimplemented(t, err)
+
+	fsID, err := client.RegisterFederatedService(ctx, nil)
+	test.RequireUnimplemented(t, err)
+	assert.Empty(t, fsID)
+
+	err = client.DeregisterFederatedService(ctx, "")
+	test.RequireUnimplemented(t, err)
+
+	fs, err := client.GetFederatedService(ctx, "")
+	test.RequireUnimplemented(t, err)
+	assert.Nil(t, fs)
+
+	err = client.UpdateFederatedService(ctx, nil)
+	test.RequireUnimplemented(t, err)
+
+	fss, err := client.ListFederatedServices(ctx)
+	test.RequireUnimplemented(t, err)
+	assert.Empty(t, fss)
+}
+
+func TestAgentClient(t *testing.T) {
+	server := test.NewTestServer(t)
+	agentsvcpb.RegisterAgentServiceServer(server.Server, &fakeAgentService{t: t})
+	server.Serve()
+
+	conn := server.CreateClientConn()
+	client := New(conn)
+	ctx := context.Background()
+
+	token, err := client.CreateAgentJoinToken(ctx, fakeClusterID, fakeTrustZoneID)
+	require.NoError(t, err)
+	assert.Equal(t, fakeAgentToken, token)
+
+	fakeBundle := &types.Bundle{TrustDomain: fakeTrustDomain}
+	err = client.UpdateTrustZoneBundle(ctx, fakeBundle)
+	require.NoError(t, err)
+
+	err = client.UpdateManagedTrustZoneBundle(ctx, fakeTrustZoneID, fakeBundle)
+	require.NoError(t, err)
+
+	status := &agentpb.AgentStatus{Status: agentpb.AgentStatusCode_AGENT_STATUS_CODE_RUNNING.Enum()}
+	err = client.UpdateAgentStatus(ctx, status)
+	require.NoError(t, err)
+
+	fakeFS := fakeFederatedService()
+	fsID, err := client.RegisterFederatedService(ctx, fakeFS)
+	require.NoError(t, err)
+	assert.EqualExportedValues(t, fakeFSID, fsID)
+
+	err = client.DeregisterFederatedService(ctx, fakeFSID)
+	require.NoError(t, err)
+
+	err = client.UpdateFederatedService(ctx, fakeFS)
+	require.NoError(t, err)
+
+	gotFS, err := client.GetFederatedService(ctx, fakeFSID)
+	require.NoError(t, err)
+	assert.EqualExportedValues(t, fakeFS, gotFS)
+
+	fss, err := client.ListFederatedServices(ctx)
+	require.NoError(t, err)
+	assert.EqualExportedValues(t, []*federatedservicepb.FederatedService{fakeFS}, fss)
+}
+
+type fakeAgentService struct {
+	t *testing.T
+}
+
+func (f *fakeAgentService) CreateAgentJoinToken(ctx context.Context, req *agentsvcpb.CreateAgentJoinTokenRequest) (*agentsvcpb.CreateAgentJoinTokenResponse, error) {
+	assert.Equal(f.t, fakeClusterID, req.GetClusterId())
+	assert.Equal(f.t, fakeTrustZoneID, req.GetTrustZoneId())
+	return &agentsvcpb.CreateAgentJoinTokenResponse{AgentToken: test.PtrOf(fakeAgentToken)}, nil
+}
+
+func (f *fakeAgentService) UpdateTrustZoneBundle(ctx context.Context, req *agentsvcpb.UpdateTrustZoneBundleRequest) (*agentsvcpb.UpdateTrustZoneBundleResponse, error) {
+	assert.Equal(f.t, fakeTrustDomain, req.Bundle.TrustDomain)
+	if req.TrustZoneId != "" {
+		assert.Equal(f.t, fakeTrustZoneID, req.GetTrustZoneId())
+	}
+	return &agentsvcpb.UpdateTrustZoneBundleResponse{}, nil
+}
+
+func (f *fakeAgentService) UpdateAgentStatus(ctx context.Context, req *agentsvcpb.UpdateAgentStatusRequest) (*agentsvcpb.UpdateAgentStatusResponse, error) {
+	assert.Equal(f.t, agentpb.AgentStatusCode_AGENT_STATUS_CODE_RUNNING, req.Status.GetStatus())
+	return &agentsvcpb.UpdateAgentStatusResponse{}, nil
+}
+
+func (f *fakeAgentService) RegisterFederatedService(ctx context.Context, req *agentsvcpb.RegisterFederatedServiceRequest) (*agentsvcpb.RegisterFederatedServiceResponse, error) {
+	assert.EqualExportedValues(f.t, fakeFederatedService(), req.Service)
+	return &agentsvcpb.RegisterFederatedServiceResponse{ServiceId: fakeFSID}, nil
+}
+
+func (f *fakeAgentService) DeregisterFederatedService(ctx context.Context, req *agentsvcpb.DeregisterFederatedServiceRequest) (*agentsvcpb.DeregisterFederatedServiceResponse, error) {
+	assert.Equal(f.t, fakeFSID, req.ServiceId)
+	return &agentsvcpb.DeregisterFederatedServiceResponse{}, nil
+}
+
+func (f *fakeAgentService) UpdateFederatedService(ctx context.Context, req *agentsvcpb.UpdateFederatedServiceRequest) (*agentsvcpb.UpdateFederatedServiceResponse, error) {
+	assert.EqualExportedValues(f.t, fakeFederatedService(), req.Service)
+	return &agentsvcpb.UpdateFederatedServiceResponse{}, nil
+}
+
+func (f *fakeAgentService) GetFederatedService(ctx context.Context, req *agentsvcpb.GetFederatedServiceRequest) (*agentsvcpb.GetFederatedServiceResponse, error) {
+	assert.Equal(f.t, fakeFSID, req.ServiceId)
+	fs := fakeFederatedService()
+	return &agentsvcpb.GetFederatedServiceResponse{Service: fs}, nil
+}
+
+func (f *fakeAgentService) ListFederatedServices(context.Context, *agentsvcpb.ListFederatedServicesRequest) (*agentsvcpb.ListFederatedServicesResponse, error) {
+	fss := []*federatedservicepb.FederatedService{fakeFederatedService()}
+	return &agentsvcpb.ListFederatedServicesResponse{Services: fss}, nil
+}
+
+func fakeFederatedService() *federatedservicepb.FederatedService {
+	return &federatedservicepb.FederatedService{
+		Id:   fakeFSID,
+		Name: fakeFSName,
+	}
+}

--- a/pkg/connect/client/clientset.go
+++ b/pkg/connect/client/clientset.go
@@ -1,0 +1,46 @@
+// Copyright 2025 Cofide Limited.
+// SPDX-License-Identifier: Apache-2.0
+
+package client
+
+import (
+	agentv1alpha1 "github.com/cofide/cofide-api-sdk/pkg/connect/client/agent/v1alpha1"
+	clusterv1alpha1 "github.com/cofide/cofide-api-sdk/pkg/connect/client/cluster/v1alpha1"
+	trustzonev1alpha1 "github.com/cofide/cofide-api-sdk/pkg/connect/client/trustzone/v1alpha1"
+	"google.golang.org/grpc"
+)
+
+// ClientSet is an interface that provides methods for accessing individual
+// versioned clients for specific gRPC services in Cofide Connect API.
+type ClientSet interface {
+	TrustZoneV1Alpha1() trustzonev1alpha1.TrustZoneClient
+	ClusterV1Alpha1() clusterv1alpha1.ClusterClient
+	AgentV1Alpha1() agentv1alpha1.AgentClient
+}
+
+type clientSet struct {
+	trustZoneV1Alpha1 trustzonev1alpha1.TrustZoneClient
+	clusterV1Alpha1   clusterv1alpha1.ClusterClient
+	agentV1Alpha1     agentv1alpha1.AgentClient
+}
+
+// New instantiates a new ClientSet for communication with a Connect API.
+func New(conn grpc.ClientConnInterface) ClientSet {
+	return &clientSet{
+		trustZoneV1Alpha1: trustzonev1alpha1.New(conn),
+		clusterV1Alpha1:   clusterv1alpha1.New(conn),
+		agentV1Alpha1:     agentv1alpha1.New(conn),
+	}
+}
+
+func (c *clientSet) TrustZoneV1Alpha1() trustzonev1alpha1.TrustZoneClient {
+	return c.trustZoneV1Alpha1
+}
+
+func (c *clientSet) ClusterV1Alpha1() clusterv1alpha1.ClusterClient {
+	return c.clusterV1Alpha1
+}
+
+func (c *clientSet) AgentV1Alpha1() agentv1alpha1.AgentClient {
+	return c.agentV1Alpha1
+}

--- a/pkg/connect/client/clientset_test.go
+++ b/pkg/connect/client/clientset_test.go
@@ -1,0 +1,18 @@
+// Copyright 2025 Cofide Limited.
+// SPDX-License-Identifier: Apache-2.0
+
+package client
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestClientSet(t *testing.T) {
+	client := New(nil)
+	require.NotNil(t, client)
+	require.NotNil(t, client.TrustZoneV1Alpha1())
+	require.NotNil(t, client.ClusterV1Alpha1())
+	require.NotNil(t, client.AgentV1Alpha1())
+}

--- a/pkg/connect/client/cluster/v1alpha1/cluster.go
+++ b/pkg/connect/client/cluster/v1alpha1/cluster.go
@@ -1,0 +1,82 @@
+// Copyright 2025 Cofide Limited.
+// SPDX-License-Identifier: Apache-2.0
+
+package v1alpha1
+
+import (
+	"context"
+
+	clusterpb "github.com/cofide/cofide-api-sdk/gen/go/proto/cluster/v1alpha1"
+	clustersvcpb "github.com/cofide/cofide-api-sdk/gen/go/proto/connect/cluster_service/v1alpha1"
+	"google.golang.org/grpc"
+)
+
+// ClusterClient is an interface for a gRPC client for the v1alpha1 version of the Connect ClusterService.
+type ClusterClient interface {
+	CreateCluster(ctx context.Context, cluster *clusterpb.Cluster) (*clusterpb.Cluster, error)
+	DestroyCluster(ctx context.Context, clusterID string) error
+	GetCluster(ctx context.Context, clusterID string) (*clusterpb.Cluster, error)
+	ListClusters(ctx context.Context, filter *clustersvcpb.ListClustersRequest_Filter) ([]*clusterpb.Cluster, error)
+	UpdateCluster(ctx context.Context, cluster *clusterpb.Cluster) (*clusterpb.Cluster, error)
+}
+
+type clusterClient struct {
+	client clustersvcpb.ClusterServiceClient
+}
+
+// New instantiates a new ClusterClient for communication with a Connect API.
+func New(conn grpc.ClientConnInterface) ClusterClient {
+	return &clusterClient{
+		client: clustersvcpb.NewClusterServiceClient(conn),
+	}
+}
+
+func (c *clusterClient) CreateCluster(ctx context.Context, cluster *clusterpb.Cluster) (*clusterpb.Cluster, error) {
+	resp, err := c.client.CreateCluster(ctx, &clustersvcpb.CreateClusterRequest{
+		Cluster: cluster,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return resp.Cluster, nil
+}
+
+func (c *clusterClient) DestroyCluster(ctx context.Context, clusterID string) error {
+	_, err := c.client.DestroyCluster(ctx, &clustersvcpb.DestroyClusterRequest{
+		ClusterId: &clusterID,
+	})
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *clusterClient) GetCluster(ctx context.Context, clusterID string) (*clusterpb.Cluster, error) {
+	resp, err := c.client.GetCluster(ctx, &clustersvcpb.GetClusterRequest{
+		ClusterId: &clusterID,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return resp.Cluster, nil
+}
+
+func (c *clusterClient) ListClusters(ctx context.Context, filter *clustersvcpb.ListClustersRequest_Filter) ([]*clusterpb.Cluster, error) {
+	resp, err := c.client.ListClusters(ctx, &clustersvcpb.ListClustersRequest{
+		Filter: filter,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return resp.Clusters, nil
+}
+
+func (c *clusterClient) UpdateCluster(ctx context.Context, cluster *clusterpb.Cluster) (*clusterpb.Cluster, error) {
+	resp, err := c.client.UpdateCluster(ctx, &clustersvcpb.UpdateClusterRequest{
+		Cluster: cluster,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return resp.Cluster, nil
+}

--- a/pkg/connect/client/cluster/v1alpha1/cluster_test.go
+++ b/pkg/connect/client/cluster/v1alpha1/cluster_test.go
@@ -1,0 +1,121 @@
+// Copyright 2025 Cofide Limited.
+// SPDX-License-Identifier: Apache-2.0
+
+package v1alpha1
+
+import (
+	"context"
+	"testing"
+
+	clusterpb "github.com/cofide/cofide-api-sdk/gen/go/proto/cluster/v1alpha1"
+	clustersvcpb "github.com/cofide/cofide-api-sdk/gen/go/proto/connect/cluster_service/v1alpha1"
+	"github.com/cofide/cofide-api-sdk/pkg/connect/client/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	fakeClusterID   = "fake-cluster-id"
+	fakeClusterName = "fake-cluster-name"
+)
+
+// TestClusterClient_Unimplemented tests ClusterClient against an unimplemented server.
+// This ensures that all errors returned are not wrapped can be converted to a gRPC Status using Status.Convert.
+func TestClusterClient_Unimplemented(t *testing.T) {
+	server := test.NewTestServer(t)
+	clustersvcpb.RegisterClusterServiceServer(server.Server, &clustersvcpb.UnimplementedClusterServiceServer{})
+	server.Serve()
+
+	conn := server.CreateClientConn()
+	client := New(conn)
+	ctx := context.Background()
+
+	token, err := client.CreateCluster(ctx, nil)
+	test.RequireUnimplemented(t, err)
+	assert.Empty(t, token)
+
+	err = client.DestroyCluster(ctx, "")
+	test.RequireUnimplemented(t, err)
+
+	cluster, err := client.GetCluster(ctx, "")
+	test.RequireUnimplemented(t, err)
+	assert.Nil(t, cluster)
+
+	clusters, err := client.ListClusters(ctx, nil)
+	test.RequireUnimplemented(t, err)
+	assert.Nil(t, clusters)
+
+	cluster, err = client.UpdateCluster(ctx, nil)
+	test.RequireUnimplemented(t, err)
+	assert.Nil(t, cluster)
+}
+
+func TestClusterClient(t *testing.T) {
+	server := test.NewTestServer(t)
+	clustersvcpb.RegisterClusterServiceServer(server.Server, &fakeClusterService{t: t})
+	server.Serve()
+
+	conn := server.CreateClientConn()
+	client := New(conn)
+	ctx := context.Background()
+
+	cluster := fakeCluster()
+
+	createdCluster, err := client.CreateCluster(ctx, cluster)
+	require.NoError(t, err)
+	assert.EqualExportedValues(t, cluster, createdCluster)
+
+	err = client.DestroyCluster(ctx, cluster.GetId())
+	require.NoError(t, err)
+
+	gotCluster, err := client.GetCluster(ctx, cluster.GetId())
+	require.NoError(t, err)
+	assert.Equal(t, cluster.GetId(), gotCluster.GetId())
+
+	filter := &clustersvcpb.ListClustersRequest_Filter{Name: test.PtrOf(fakeClusterName)}
+	clusters, err := client.ListClusters(ctx, filter)
+	require.NoError(t, err)
+	assert.EqualExportedValues(t, []*clusterpb.Cluster{fakeCluster()}, clusters)
+
+	updatedCluster, err := client.UpdateCluster(ctx, cluster)
+	require.NoError(t, err)
+	assert.EqualExportedValues(t, cluster, updatedCluster)
+}
+
+// fakeClusterService provides a very simple fake ClusterService implementation with canned responses.
+type fakeClusterService struct {
+	t *testing.T
+}
+
+func (f *fakeClusterService) CreateCluster(ctx context.Context, req *clustersvcpb.CreateClusterRequest) (*clustersvcpb.CreateClusterResponse, error) {
+	assert.EqualExportedValues(f.t, fakeCluster(), req.Cluster)
+	return &clustersvcpb.CreateClusterResponse{Cluster: req.Cluster}, nil
+}
+
+func (f *fakeClusterService) DestroyCluster(ctx context.Context, req *clustersvcpb.DestroyClusterRequest) (*clustersvcpb.DestroyClusterResponse, error) {
+	assert.Equal(f.t, fakeClusterID, req.GetClusterId())
+	return &clustersvcpb.DestroyClusterResponse{}, nil
+}
+
+func (f *fakeClusterService) GetCluster(ctx context.Context, req *clustersvcpb.GetClusterRequest) (*clustersvcpb.GetClusterResponse, error) {
+	assert.Equal(f.t, fakeClusterID, req.GetClusterId())
+	return &clustersvcpb.GetClusterResponse{Cluster: fakeCluster()}, nil
+}
+
+func (f *fakeClusterService) ListClusters(ctx context.Context, req *clustersvcpb.ListClustersRequest) (*clustersvcpb.ListClustersResponse, error) {
+	assert.Equal(f.t, fakeClusterName, req.Filter.GetName())
+	clusters := []*clusterpb.Cluster{fakeCluster()}
+	return &clustersvcpb.ListClustersResponse{Clusters: clusters}, nil
+}
+
+func (f *fakeClusterService) UpdateCluster(ctx context.Context, req *clustersvcpb.UpdateClusterRequest) (*clustersvcpb.UpdateClusterResponse, error) {
+	assert.EqualExportedValues(f.t, fakeCluster(), req.Cluster)
+	return &clustersvcpb.UpdateClusterResponse{Cluster: fakeCluster()}, nil
+}
+
+func fakeCluster() *clusterpb.Cluster {
+	return &clusterpb.Cluster{
+		Id:   test.PtrOf(fakeClusterID),
+		Name: test.PtrOf(fakeClusterName),
+	}
+}

--- a/pkg/connect/client/test/server.go
+++ b/pkg/connect/client/test/server.go
@@ -1,0 +1,54 @@
+// Copyright 2025 Cofide Limited.
+// SPDX-License-Identifier: Apache-2.0
+
+package test
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/test/bufconn"
+)
+
+const bufSize = 1024 * 1024
+
+// TestServer provides a gRPC server for testing with an in-memory bufconn transport.
+type TestServer struct {
+	t        *testing.T
+	Listener *bufconn.Listener
+	Server   *grpc.Server
+}
+
+func NewTestServer(t *testing.T) *TestServer {
+	return &TestServer{
+		t:        t,
+		Listener: bufconn.Listen(bufSize),
+		Server:   grpc.NewServer(),
+	}
+}
+
+func (ts *TestServer) Serve() {
+	go func() {
+		err := ts.Server.Serve(ts.Listener)
+		require.NoError(ts.t, err)
+	}()
+}
+
+// BuildTestConn creates a gRPC client connection for the provided TestServer.
+func (ts *TestServer) CreateClientConn() *grpc.ClientConn {
+	bufDialer := func(context.Context, string) (net.Conn, error) {
+		return ts.Listener.Dial()
+	}
+
+	conn, err := grpc.NewClient(
+		"passthrough://bufnet",
+		grpc.WithContextDialer(bufDialer),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	require.NoError(ts.t, err)
+	return conn
+}

--- a/pkg/connect/client/test/utils.go
+++ b/pkg/connect/client/test/utils.go
@@ -1,0 +1,23 @@
+package test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// RequireUnimplemented requires that an error is a gRPC Status with the Unimplemented code.
+func RequireUnimplemented(t *testing.T, err error) {
+	t.Helper()
+	require.Error(t, err)
+	status := status.Convert(err)
+	require.NotNil(t, status)
+	assert.Equal(t, codes.Unimplemented, status.Code())
+}
+
+func PtrOf[T any](val T) *T {
+	return &val
+}

--- a/pkg/connect/client/trustzone/v1alpha1/trustzone.go
+++ b/pkg/connect/client/trustzone/v1alpha1/trustzone.go
@@ -1,0 +1,96 @@
+// Copyright 2025 Cofide Limited.
+// SPDX-License-Identifier: Apache-2.0
+
+package v1alpha1
+
+import (
+	"context"
+
+	clusterpb "github.com/cofide/cofide-api-sdk/gen/go/proto/cluster/v1alpha1"
+	trustzonesvcpb "github.com/cofide/cofide-api-sdk/gen/go/proto/connect/trust_zone_service/v1alpha1"
+	trustzonepb "github.com/cofide/cofide-api-sdk/gen/go/proto/trust_zone/v1alpha1"
+	"github.com/spiffe/spire-api-sdk/proto/spire/api/types"
+	"google.golang.org/grpc"
+)
+
+// TrustZoneClient is an interface for a gRPC client for the v1alpha1 version of the Connect TrustZoneService.
+type TrustZoneClient interface {
+	CreateTrustZone(ctx context.Context, trustZone *trustzonepb.TrustZone) (*trustzonepb.TrustZone, error)
+	GetTrustZone(ctx context.Context, trustZoneID string) (*trustzonepb.TrustZone, error)
+	ListTrustZones(ctx context.Context, filter *trustzonesvcpb.ListTrustZonesRequest_Filter) ([]*trustzonepb.TrustZone, error)
+	// DEPRECATED: Agent join token creation moved to AgentService.CreateAgentJoinToken.
+	// Cluster creation to be moved to ClusterService.CreateCluster.
+	RegisterCluster(ctx context.Context, trustZoneID string, cluster *clusterpb.Cluster) (string, error)
+	RegisterAgent(ctx context.Context, agent *trustzonesvcpb.Agent, token string, bundle *types.Bundle) (string, error)
+}
+
+type trustZoneClient struct {
+	trustZoneClient trustzonesvcpb.TrustZoneServiceClient
+}
+
+// New instantiates a new TrustZoneClient for communication with a Connect API.
+func New(conn grpc.ClientConnInterface) TrustZoneClient {
+	return &trustZoneClient{
+		trustZoneClient: trustzonesvcpb.NewTrustZoneServiceClient(conn),
+	}
+}
+
+func (c *trustZoneClient) CreateTrustZone(ctx context.Context, trustZone *trustzonepb.TrustZone) (*trustzonepb.TrustZone, error) {
+	resp, err := c.trustZoneClient.CreateTrustZone(ctx, &trustzonesvcpb.CreateTrustZoneRequest{
+		TrustZone: trustZone,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return resp.TrustZone, nil
+}
+
+func (c *trustZoneClient) GetTrustZone(ctx context.Context, trustZoneID string) (*trustzonepb.TrustZone, error) {
+	resp, err := c.trustZoneClient.GetTrustZoneDetails(ctx, &trustzonesvcpb.GetTrustZoneDetailsRequest{
+		TrustZoneId: trustZoneID,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return resp.TrustZone, nil
+}
+
+func (c *trustZoneClient) ListTrustZones(ctx context.Context, filter *trustzonesvcpb.ListTrustZonesRequest_Filter) ([]*trustzonepb.TrustZone, error) {
+	resp, err := c.trustZoneClient.ListTrustZones(ctx, &trustzonesvcpb.ListTrustZonesRequest{
+		Filter: filter,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return resp.TrustZones, nil
+}
+
+// DEPRECATED: Agent join token creation moved to AgentService.CreateAgentJoinToken.
+// Cluster creation to be moved to ClusterService.CreateCluster.
+func (c *trustZoneClient) RegisterCluster(ctx context.Context, trustZoneID string, cluster *clusterpb.Cluster) (string, error) {
+	resp, err := c.trustZoneClient.RegisterCluster(ctx, &trustzonesvcpb.RegisterClusterRequest{
+		TrustZoneId: trustZoneID,
+		Cluster:     cluster,
+	})
+	if err != nil {
+		return "", err
+	}
+
+	return resp.AgentToken, nil
+}
+
+func (c *trustZoneClient) RegisterAgent(ctx context.Context, agent *trustzonesvcpb.Agent, token string, bundle *types.Bundle) (string, error) {
+	resp, err := c.trustZoneClient.RegisterAgent(ctx, &trustzonesvcpb.RegisterAgentRequest{
+		Agent:      agent,
+		AgentToken: token,
+		Bundle:     bundle,
+	})
+	if err != nil {
+		return "", err
+	}
+
+	return resp.AgentId, nil
+}

--- a/pkg/connect/client/trustzone/v1alpha1/trustzone_test.go
+++ b/pkg/connect/client/trustzone/v1alpha1/trustzone_test.go
@@ -1,0 +1,150 @@
+// Copyright 2025 Cofide Limited.
+// SPDX-License-Identifier: Apache-2.0
+
+package v1alpha1
+
+import (
+	"context"
+	"testing"
+
+	clusterpb "github.com/cofide/cofide-api-sdk/gen/go/proto/cluster/v1alpha1"
+	trustzonesvcpb "github.com/cofide/cofide-api-sdk/gen/go/proto/connect/trust_zone_service/v1alpha1"
+	trustzonepb "github.com/cofide/cofide-api-sdk/gen/go/proto/trust_zone/v1alpha1"
+	"github.com/cofide/cofide-api-sdk/pkg/connect/client/test"
+	"github.com/spiffe/spire-api-sdk/proto/spire/api/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	fakeTrustZoneID   = "fake-tz-id"
+	fakeTrustZoneName = "fake-tz-name"
+	fakeClusterID     = "fake-cluster-id"
+	fakeClusterName   = "fake-cluster-name"
+	fakeAgentToken    = "fake-agent-token"
+	fakeAgentID       = "fake-agent-id"
+	fakeTrustDomain   = "fake.trust.domain"
+)
+
+// TestTrustZoneClient_Unimplemented tests TrustZoneClient against an unimplemented server.
+// This ensures that all errors returned are not wrapped can be converted to a gRPC Status using Status.Convert.
+func TestTrustZoneClient_Unimplemented(t *testing.T) {
+	server := test.NewTestServer(t)
+	trustzonesvcpb.RegisterTrustZoneServiceServer(server.Server, &trustzonesvcpb.UnimplementedTrustZoneServiceServer{})
+	server.Serve()
+
+	conn := server.CreateClientConn()
+	client := New(conn)
+	ctx := context.Background()
+
+	trustZone, err := client.CreateTrustZone(ctx, nil)
+	test.RequireUnimplemented(t, err)
+	assert.Nil(t, trustZone)
+
+	trustZone, err = client.GetTrustZone(ctx, "")
+	test.RequireUnimplemented(t, err)
+	assert.Nil(t, trustZone)
+
+	trustZones, err := client.ListTrustZones(ctx, nil)
+	test.RequireUnimplemented(t, err)
+	assert.Nil(t, trustZones)
+
+	token, err := client.RegisterCluster(ctx, "", nil)
+	test.RequireUnimplemented(t, err)
+	assert.Empty(t, token)
+
+	agentID, err := client.RegisterAgent(ctx, nil, "", nil)
+	test.RequireUnimplemented(t, err)
+	assert.Empty(t, agentID)
+}
+
+func TestTrustZoneClient(t *testing.T) {
+	server := test.NewTestServer(t)
+	trustzonesvcpb.RegisterTrustZoneServiceServer(server.Server, &fakeTrustZoneService{t: t})
+	server.Serve()
+
+	conn := server.CreateClientConn()
+	client := New(conn)
+	ctx := context.Background()
+
+	trustZone := fakeTrustZone()
+
+	createdTrustZone, err := client.CreateTrustZone(ctx, trustZone)
+	require.NoError(t, err)
+	assert.EqualExportedValues(t, trustZone, createdTrustZone)
+
+	gotTrustZone, err := client.GetTrustZone(ctx, fakeTrustZoneID)
+	require.NoError(t, err)
+	assert.EqualExportedValues(t, trustZone, gotTrustZone)
+
+	filter := &trustzonesvcpb.ListTrustZonesRequest_Filter{Name: test.PtrOf(fakeTrustZoneName)}
+	trustZones, err := client.ListTrustZones(ctx, filter)
+	require.NoError(t, err)
+	assert.EqualExportedValues(t, []*trustzonepb.TrustZone{trustZone}, trustZones)
+
+	cluster := fakeCluster()
+	token, err := client.RegisterCluster(ctx, fakeTrustZoneID, cluster)
+	require.NoError(t, err)
+	assert.Equal(t, fakeAgentToken, token)
+
+	agent := fakeAgent()
+	bundle := &types.Bundle{TrustDomain: fakeTrustDomain}
+	agentID, err := client.RegisterAgent(ctx, agent, fakeAgentToken, bundle)
+	require.NoError(t, err)
+	assert.Equal(t, fakeAgentID, agentID)
+}
+
+type fakeTrustZoneService struct {
+	t *testing.T
+}
+
+func (f *fakeTrustZoneService) CreateTrustZone(ctx context.Context, req *trustzonesvcpb.CreateTrustZoneRequest) (*trustzonesvcpb.CreateTrustZoneResponse, error) {
+	assert.EqualExportedValues(f.t, fakeTrustZone(), req.TrustZone)
+	return &trustzonesvcpb.CreateTrustZoneResponse{TrustZone: req.TrustZone}, nil
+}
+
+func (f *fakeTrustZoneService) ListTrustZones(ctx context.Context, req *trustzonesvcpb.ListTrustZonesRequest) (*trustzonesvcpb.ListTrustZonesResponse, error) {
+	assert.Equal(f.t, fakeTrustZoneName, req.Filter.GetName())
+	trustZones := []*trustzonepb.TrustZone{fakeTrustZone()}
+	return &trustzonesvcpb.ListTrustZonesResponse{TrustZones: trustZones}, nil
+}
+
+func (f *fakeTrustZoneService) GetTrustZoneDetails(ctx context.Context, req *trustzonesvcpb.GetTrustZoneDetailsRequest) (*trustzonesvcpb.GetTrustZoneDetailsResponse, error) {
+	assert.EqualExportedValues(f.t, fakeTrustZoneID, req.TrustZoneId)
+	return &trustzonesvcpb.GetTrustZoneDetailsResponse{TrustZone: fakeTrustZone()}, nil
+}
+
+func (f *fakeTrustZoneService) RegisterCluster(ctx context.Context, req *trustzonesvcpb.RegisterClusterRequest) (*trustzonesvcpb.RegisterClusterResponse, error) {
+	assert.EqualExportedValues(f.t, fakeCluster(), req.Cluster)
+	assert.Equal(f.t, fakeTrustZoneID, req.TrustZoneId)
+	return &trustzonesvcpb.RegisterClusterResponse{AgentToken: fakeAgentToken}, nil
+}
+
+func (f *fakeTrustZoneService) RegisterAgent(ctx context.Context, req *trustzonesvcpb.RegisterAgentRequest) (*trustzonesvcpb.RegisterAgentResponse, error) {
+	assert.EqualExportedValues(f.t, fakeAgent(), req.Agent)
+	assert.Equal(f.t, fakeAgentToken, req.AgentToken)
+	assert.Equal(f.t, fakeTrustDomain, req.Bundle.TrustDomain)
+	return &trustzonesvcpb.RegisterAgentResponse{AgentId: fakeAgentID}, nil
+}
+
+func fakeTrustZone() *trustzonepb.TrustZone {
+	return &trustzonepb.TrustZone{
+		Id:   test.PtrOf(fakeTrustZoneID),
+		Name: fakeTrustZoneName,
+	}
+}
+
+func fakeCluster() *clusterpb.Cluster {
+	return &clusterpb.Cluster{
+		Id:   test.PtrOf(fakeClusterID),
+		Name: test.PtrOf(fakeClusterName),
+	}
+}
+
+func fakeAgent() *trustzonesvcpb.Agent {
+	return &trustzonesvcpb.Agent{
+		AgentId:     fakeAgentID,
+		ClusterId:   fakeClusterID,
+		TrustZoneId: fakeTrustZoneID,
+	}
+}


### PR DESCRIPTION
- **feat: Add Connect client**
    This PR adds a client implementation for the Cofide Connect API. It
    is a fairly lightweight wrapper around the gRPC clients, with a
    ClientSet modelled on the Kubernetes client-go module.

- **test: Add Go Just targets and GitHub CI workflows**
