### PR TITLE
test: add fake clients for testing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.23.0
 toolchain go1.23.6
 
 require (
+	github.com/google/uuid v1.6.0
 	github.com/spiffe/spire-api-sdk v1.11.2
 	github.com/stretchr/testify v1.10.0
 	google.golang.org/grpc v1.71.0

--- a/pkg/connect/client/agent/v1alpha1/fake/fake.go
+++ b/pkg/connect/client/agent/v1alpha1/fake/fake.go
@@ -1,0 +1,178 @@
+// Copyright 2025 Cofide Limited.
+// SPDX-License-Identifier: Apache-2.0
+
+package fake
+
+import (
+	"context"
+
+	agentpb "github.com/cofide/cofide-api-sdk/gen/go/proto/agent/v1alpha1"
+	federatedservicepb "github.com/cofide/cofide-api-sdk/gen/go/proto/federated_service/v1alpha1"
+	agentv1alpha1 "github.com/cofide/cofide-api-sdk/pkg/connect/client/agent/v1alpha1"
+	fakeconnect "github.com/cofide/cofide-api-sdk/pkg/connect/client/fake/connect"
+	"github.com/google/uuid"
+	"github.com/spiffe/spire-api-sdk/proto/spire/api/types"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
+)
+
+type fakeAgentClient struct {
+	fake *fakeconnect.FakeConnect
+}
+
+// New instantiates a new AgentClient for communication with a fake Connect API.
+func New(fake *fakeconnect.FakeConnect) agentv1alpha1.AgentClient {
+	return &fakeAgentClient{
+		fake: fake,
+	}
+}
+
+func (c *fakeAgentClient) CreateAgentJoinToken(ctx context.Context, clusterID, trustZoneID string) (string, error) {
+	c.fake.Mu.Lock()
+	defer c.fake.Mu.Unlock()
+
+	if err := c.fake.ValidateTrustZone(trustZoneID); err != nil {
+		return "", err
+	}
+	if err := c.fake.ValidateCluster(clusterID); err != nil {
+		return "", err
+	}
+
+	if c.fake.AgentJoinTokens[trustZoneID] == nil {
+		c.fake.AgentJoinTokens[trustZoneID] = make(map[string]string)
+	}
+	token := uuid.New().String()
+	c.fake.AgentJoinTokens[trustZoneID][clusterID] = token
+	return token, nil
+}
+
+func (c *fakeAgentClient) UpdateTrustZoneBundle(ctx context.Context, bundle *types.Bundle) error {
+	c.fake.Mu.Lock()
+	defer c.fake.Mu.Unlock()
+
+	agentID, err := getAgentIDFromMetadata(ctx)
+	if err != nil {
+		return err
+	}
+
+	if err := c.fake.ValidateAgent(agentID); err != nil {
+		return err
+	}
+
+	agent := c.fake.Agents[agentID]
+	c.fake.TrustZoneBundles[agent.GetTrustZoneId()] = cloneBundle(bundle)
+	return nil
+}
+
+func (c *fakeAgentClient) UpdateManagedTrustZoneBundle(ctx context.Context, trustZoneID string, bundle *types.Bundle) error {
+	c.fake.Mu.Lock()
+	defer c.fake.Mu.Unlock()
+
+	if err := c.fake.ValidateTrustZone(trustZoneID); err != nil {
+		return err
+	}
+
+	c.fake.TrustZoneBundles[trustZoneID] = cloneBundle(bundle)
+	return nil
+}
+
+func (c *fakeAgentClient) UpdateAgentStatus(ctx context.Context, agentStatus *agentpb.AgentStatus) error {
+	c.fake.Mu.Lock()
+	defer c.fake.Mu.Unlock()
+
+	agentID, err := getAgentIDFromMetadata(ctx)
+	if err != nil {
+		return err
+	}
+
+	if err := c.fake.ValidateAgent(agentID); err != nil {
+		return err
+	}
+
+	c.fake.AgentStatus[agentID] = cloneStatus(agentStatus)
+	return nil
+}
+
+func (c *fakeAgentClient) RegisterFederatedService(ctx context.Context, fs *federatedservicepb.FederatedService) (string, error) {
+	c.fake.Mu.Lock()
+	defer c.fake.Mu.Unlock()
+
+	if _, ok := c.fake.FederatedServices[fs.Id]; ok {
+		return "", status.Error(codes.AlreadyExists, "federated service already exists")
+	}
+
+	c.fake.FederatedServices[fs.Id] = cloneFS(fs)
+	return fs.Id, nil
+}
+
+func (c *fakeAgentClient) DeregisterFederatedService(ctx context.Context, federatedServiceID string) error {
+	c.fake.Mu.Lock()
+	defer c.fake.Mu.Unlock()
+
+	if err := c.fake.ValidateFederatedService(federatedServiceID); err != nil {
+		return status.Error(codes.NotFound, "federated service not found")
+	}
+
+	delete(c.fake.FederatedServices, federatedServiceID)
+	return nil
+}
+
+func (c *fakeAgentClient) GetFederatedService(ctx context.Context, federatedServiceID string) (*federatedservicepb.FederatedService, error) {
+	c.fake.Mu.Lock()
+	defer c.fake.Mu.Unlock()
+
+	if err := c.fake.ValidateFederatedService(federatedServiceID); err != nil {
+		return nil, status.Error(codes.NotFound, "federated service not found")
+	}
+
+	return cloneFS(c.fake.FederatedServices[federatedServiceID]), nil
+}
+
+func (c *fakeAgentClient) UpdateFederatedService(ctx context.Context, fs *federatedservicepb.FederatedService) error {
+	c.fake.Mu.Lock()
+	defer c.fake.Mu.Unlock()
+
+	if err := c.fake.ValidateFederatedService(fs.GetId()); err != nil {
+		return status.Error(codes.NotFound, "federated service not found")
+	}
+
+	c.fake.FederatedServices[fs.GetId()] = cloneFS(fs)
+	return nil
+}
+
+func (c *fakeAgentClient) ListFederatedServices(ctx context.Context) ([]*federatedservicepb.FederatedService, error) {
+	c.fake.Mu.Lock()
+	defer c.fake.Mu.Unlock()
+
+	fss := []*federatedservicepb.FederatedService{}
+	for _, fs := range c.fake.FederatedServices {
+		fss = append(fss, cloneFS(fs))
+	}
+	return fss, nil
+}
+
+func cloneBundle(bundle *types.Bundle) *types.Bundle {
+	return proto.Clone(bundle).(*types.Bundle)
+}
+
+func cloneStatus(status *agentpb.AgentStatus) *agentpb.AgentStatus {
+	return proto.Clone(status).(*agentpb.AgentStatus)
+}
+
+func cloneFS(fs *federatedservicepb.FederatedService) *federatedservicepb.FederatedService {
+	return proto.Clone(fs).(*federatedservicepb.FederatedService)
+}
+
+func getAgentIDFromMetadata(ctx context.Context) (string, error) {
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		return "", status.Error(codes.Unauthenticated, "missing gRPC metadata")
+	}
+	agentIDs := md.Get("agent-id")
+	if len(agentIDs) != 1 {
+		return "", status.Error(codes.Unauthenticated, "missing agent ID gRPC metadata")
+	}
+	return agentIDs[0], nil
+}

--- a/pkg/connect/client/agent/v1alpha1/fake/fake_test.go
+++ b/pkg/connect/client/agent/v1alpha1/fake/fake_test.go
@@ -1,0 +1,178 @@
+// Copyright 2025 Cofide Limited.
+// SPDX-License-Identifier: Apache-2.0
+
+package fake
+
+import (
+	"context"
+	"testing"
+
+	agentpb "github.com/cofide/cofide-api-sdk/gen/go/proto/agent/v1alpha1"
+	federatedservicepb "github.com/cofide/cofide-api-sdk/gen/go/proto/federated_service/v1alpha1"
+	fakeconnect "github.com/cofide/cofide-api-sdk/pkg/connect/client/fake/connect"
+	"github.com/cofide/cofide-api-sdk/pkg/connect/client/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/metadata"
+)
+
+func Test_fakeAgentClient_CreateAgentJoinToken(t *testing.T) {
+	fake := fakeconnect.New()
+	client := New(fake)
+	ctx := context.Background()
+
+	_, err := client.CreateAgentJoinToken(ctx, test.FakeClusterID, test.FakeTrustZoneID)
+	require.Error(t, err)
+
+	fake.TrustZones[test.FakeTrustZoneID] = test.FakeTrustZone()
+
+	_, err = client.CreateAgentJoinToken(ctx, test.FakeClusterID, test.FakeTrustZoneID)
+	require.Error(t, err)
+
+	fake.Clusters[test.FakeClusterID] = test.FakeCluster()
+
+	token, err := client.CreateAgentJoinToken(ctx, test.FakeClusterID, test.FakeTrustZoneID)
+	require.NoError(t, err)
+	assert.Equal(t, fake.AgentJoinTokens[test.FakeTrustZoneID][test.FakeClusterID], token)
+}
+
+func Test_fakeAgentClient_UpdateTrustZoneBundle(t *testing.T) {
+	fake := fakeconnect.New()
+	client := New(fake)
+	ctx := context.Background()
+
+	fakeBundle := test.FakeBundle()
+
+	err := client.UpdateTrustZoneBundle(ctx, fakeBundle)
+	require.Error(t, err)
+
+	md := metadata.MD{"agent-id": []string{test.FakeAgentID}}
+	ctx = metadata.NewIncomingContext(ctx, md)
+
+	err = client.UpdateTrustZoneBundle(ctx, fakeBundle)
+	require.Error(t, err)
+
+	fake.TrustZones[test.FakeTrustZoneID] = test.FakeTrustZone()
+
+	err = client.UpdateTrustZoneBundle(ctx, fakeBundle)
+	require.Error(t, err)
+
+	fake.Agents[test.FakeAgentID] = test.FakeAgent()
+
+	err = client.UpdateTrustZoneBundle(ctx, fakeBundle)
+	require.NoError(t, err)
+	assert.Equal(t, fake.TrustZoneBundles[test.FakeTrustZoneID], fakeBundle)
+}
+
+func Test_fakeAgentClient_UpdateManagedTrustZoneBundle(t *testing.T) {
+	fake := fakeconnect.New()
+	client := New(fake)
+	ctx := context.Background()
+
+	fakeBundle := test.FakeBundle()
+	err := client.UpdateManagedTrustZoneBundle(ctx, test.FakeTrustZoneID, fakeBundle)
+	require.Error(t, err)
+
+	fake.TrustZones[test.FakeTrustZoneID] = test.FakeTrustZone()
+
+	err = client.UpdateManagedTrustZoneBundle(ctx, test.FakeTrustZoneID, fakeBundle)
+	require.NoError(t, err)
+	assert.Equal(t, fake.TrustZoneBundles[test.FakeTrustZoneID], fakeBundle)
+}
+
+func Test_fakeAgentClient_UpdateAgentStatus(t *testing.T) {
+	fake := fakeconnect.New()
+	client := New(fake)
+	ctx := context.Background()
+
+	md := metadata.MD{"agent-id": []string{test.FakeAgentID}}
+	ctx = metadata.NewIncomingContext(ctx, md)
+
+	agentStatus := &agentpb.AgentStatus{Status: agentpb.AgentStatusCode_AGENT_STATUS_CODE_RUNNING.Enum()}
+	err := client.UpdateAgentStatus(ctx, agentStatus)
+	require.Error(t, err)
+
+	fake.Agents[test.FakeAgentID] = test.FakeAgent()
+
+	err = client.UpdateAgentStatus(ctx, agentStatus)
+	require.NoError(t, err)
+	assert.EqualExportedValues(t, agentStatus, fake.AgentStatus[test.FakeAgentID])
+}
+
+func Test_fakeAgentClient_RegisterFederatedService(t *testing.T) {
+	fake := fakeconnect.New()
+	client := New(fake)
+	ctx := context.Background()
+
+	fakeFS := test.FakeFederatedService()
+	fsID, err := client.RegisterFederatedService(ctx, fakeFS)
+	require.NoError(t, err)
+	assert.Equal(t, fsID, fakeFS.Id)
+	assert.EqualExportedValues(t, fakeFS, fake.FederatedServices[fsID])
+
+	_, err = client.RegisterFederatedService(ctx, fakeFS)
+	require.Error(t, err)
+}
+
+func Test_fakeAgentClient_DeregisterFederatedService(t *testing.T) {
+	fake := fakeconnect.New()
+	client := New(fake)
+	ctx := context.Background()
+
+	err := client.DeregisterFederatedService(ctx, test.FakeFSID)
+	require.Error(t, err)
+
+	fake.FederatedServices[test.FakeFSID] = test.FakeFederatedService()
+
+	err = client.DeregisterFederatedService(ctx, test.FakeFSID)
+	require.NoError(t, err)
+}
+
+func Test_fakeAgentClient_UpdateFederatedService(t *testing.T) {
+	fake := fakeconnect.New()
+	client := New(fake)
+	ctx := context.Background()
+
+	fakeFS := test.FakeFederatedService()
+
+	err := client.UpdateFederatedService(ctx, fakeFS)
+	require.Error(t, err)
+
+	fake.FederatedServices[test.FakeFSID] = fakeFS
+
+	err = client.UpdateFederatedService(ctx, fakeFS)
+	require.NoError(t, err)
+}
+
+func Test_fakeAgentClient_GetFederatedService(t *testing.T) {
+	fake := fakeconnect.New()
+	client := New(fake)
+	ctx := context.Background()
+
+	_, err := client.GetFederatedService(ctx, test.FakeFSID)
+	require.Error(t, err)
+
+	fakeFS := test.FakeFederatedService()
+	fake.FederatedServices[test.FakeFSID] = fakeFS
+
+	gotFS, err := client.GetFederatedService(ctx, test.FakeFSID)
+	require.NoError(t, err)
+	assert.EqualExportedValues(t, fakeFS, gotFS)
+}
+
+func Test_fakeAgentClient_ListFederatedServices(t *testing.T) {
+	fake := fakeconnect.New()
+	client := New(fake)
+	ctx := context.Background()
+
+	fss, err := client.ListFederatedServices(ctx)
+	require.NoError(t, err)
+	assert.EqualExportedValues(t, []*federatedservicepb.FederatedService{}, fss)
+
+	fakeFS := test.FakeFederatedService()
+	fake.FederatedServices[test.FakeFSID] = fakeFS
+
+	fss, err = client.ListFederatedServices(ctx)
+	require.NoError(t, err)
+	assert.EqualExportedValues(t, []*federatedservicepb.FederatedService{fakeFS}, fss)
+}

--- a/pkg/connect/client/cluster/v1alpha1/fake/fake.go
+++ b/pkg/connect/client/cluster/v1alpha1/fake/fake.go
@@ -1,0 +1,106 @@
+// Copyright 2025 Cofide Limited.
+// SPDX-License-Identifier: Apache-2.0
+
+package fake
+
+import (
+	"context"
+
+	clusterpb "github.com/cofide/cofide-api-sdk/gen/go/proto/cluster/v1alpha1"
+	clustersvcpb "github.com/cofide/cofide-api-sdk/gen/go/proto/connect/cluster_service/v1alpha1"
+	clusterv1alpha1 "github.com/cofide/cofide-api-sdk/pkg/connect/client/cluster/v1alpha1"
+	fakeconnect "github.com/cofide/cofide-api-sdk/pkg/connect/client/fake/connect"
+	"github.com/google/uuid"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
+)
+
+type fakeClusterClient struct {
+	fake *fakeconnect.FakeConnect
+}
+
+// New instantiates a new ClusterClient for communication with a fake Connect API.
+func New(fake *fakeconnect.FakeConnect) clusterv1alpha1.ClusterClient {
+	return &fakeClusterClient{fake: fake}
+}
+
+func (c *fakeClusterClient) CreateCluster(ctx context.Context, cluster *clusterpb.Cluster) (*clusterpb.Cluster, error) {
+	c.fake.Mu.Lock()
+	defer c.fake.Mu.Unlock()
+
+	if err := c.fake.ValidateTrustZone(cluster.GetTrustZoneId()); err != nil {
+		return nil, err
+	}
+	id := uuid.New().String()
+	cluster = clone(cluster)
+	cluster.Id = &id
+	c.fake.Clusters[cluster.GetId()] = cluster
+	return clone(cluster), nil
+}
+
+func (c *fakeClusterClient) DestroyCluster(ctx context.Context, clusterID string) error {
+	c.fake.Mu.Lock()
+	defer c.fake.Mu.Unlock()
+
+	if _, ok := c.fake.Clusters[clusterID]; !ok {
+		return status.Error(codes.NotFound, "cluster not found")
+	}
+	delete(c.fake.Clusters, clusterID)
+	return nil
+}
+
+func (c *fakeClusterClient) GetCluster(ctx context.Context, clusterID string) (*clusterpb.Cluster, error) {
+	cluster, ok := c.fake.Clusters[clusterID]
+	if !ok {
+		return nil, status.Error(codes.NotFound, "cluster not found")
+	}
+	return clone(cluster), nil
+}
+
+func (c *fakeClusterClient) ListClusters(ctx context.Context, filter *clustersvcpb.ListClustersRequest_Filter) ([]*clusterpb.Cluster, error) {
+	c.fake.Mu.Lock()
+	defer c.fake.Mu.Unlock()
+
+	clusters := []*clusterpb.Cluster{}
+	for _, cluster := range c.fake.Clusters {
+		if clusterMatches(cluster, filter) {
+			clusters = append(clusters, clone(cluster))
+		}
+	}
+	return clusters, nil
+}
+
+func clusterMatches(cluster *clusterpb.Cluster, filter *clustersvcpb.ListClustersRequest_Filter) bool {
+	if filter == nil {
+		return true
+	}
+	if filter.Name != nil && cluster.GetName() != *filter.Name {
+		return false
+	}
+	if filter.OrgId != nil && cluster.GetOrgId() != *filter.OrgId {
+		return false
+	}
+	if filter.TrustZoneId != nil && cluster.GetTrustZoneId() != *filter.TrustZoneId {
+		return false
+	}
+	return true
+}
+
+func (c *fakeClusterClient) UpdateCluster(ctx context.Context, cluster *clusterpb.Cluster) (*clusterpb.Cluster, error) {
+	c.fake.Mu.Lock()
+	defer c.fake.Mu.Unlock()
+
+	if _, ok := c.fake.Clusters[cluster.GetId()]; !ok {
+		return nil, status.Error(codes.NotFound, "")
+	}
+	if _, ok := c.fake.TrustZones[cluster.GetTrustZoneId()]; !ok {
+		return nil, status.Error(codes.InvalidArgument, "")
+	}
+	c.fake.Clusters[cluster.GetId()] = clone(cluster)
+	return clone(cluster), nil
+}
+
+func clone(cluster *clusterpb.Cluster) *clusterpb.Cluster {
+	return proto.Clone(cluster).(*clusterpb.Cluster)
+}

--- a/pkg/connect/client/cluster/v1alpha1/fake/fake_test.go
+++ b/pkg/connect/client/cluster/v1alpha1/fake/fake_test.go
@@ -1,0 +1,102 @@
+// Copyright 2025 Cofide Limited.
+// SPDX-License-Identifier: Apache-2.0
+
+package fake
+
+import (
+	"context"
+	"testing"
+
+	clusterpb "github.com/cofide/cofide-api-sdk/gen/go/proto/cluster/v1alpha1"
+	fakeconnect "github.com/cofide/cofide-api-sdk/pkg/connect/client/fake/connect"
+	"github.com/cofide/cofide-api-sdk/pkg/connect/client/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_fakeClusterClient_CreateCluster(t *testing.T) {
+	fake := fakeconnect.New()
+	client := New(fake)
+	ctx := context.Background()
+
+	cluster := test.FakeCluster()
+
+	_, err := client.CreateCluster(ctx, cluster)
+	require.Error(t, err)
+
+	fake.TrustZones[test.FakeTrustZoneID] = test.FakeTrustZone()
+
+	createdCluster, err := client.CreateCluster(ctx, cluster)
+	require.NoError(t, err)
+	cluster.Id = createdCluster.Id
+	assert.EqualExportedValues(t, cluster, createdCluster)
+	assert.EqualExportedValues(t, cluster, fake.Clusters[*createdCluster.Id])
+}
+
+func Test_fakeClusterClient_DestroyCluster(t *testing.T) {
+	fake := fakeconnect.New()
+	client := New(fake)
+	ctx := context.Background()
+
+	err := client.DestroyCluster(ctx, test.FakeClusterID)
+	require.Error(t, err)
+
+	fake.Clusters[test.FakeClusterID] = test.FakeCluster()
+
+	err = client.DestroyCluster(ctx, test.FakeClusterID)
+	require.NoError(t, err)
+	require.Nil(t, fake.Clusters[test.FakeClusterID])
+}
+
+func Test_fakeClusterClient_GetCluster(t *testing.T) {
+	fake := fakeconnect.New()
+	client := New(fake)
+	ctx := context.Background()
+
+	_, err := client.GetCluster(ctx, test.FakeClusterID)
+	require.Error(t, err)
+
+	cluster := test.FakeCluster()
+	fake.Clusters[test.FakeClusterID] = cluster
+
+	gotCluster, err := client.GetCluster(ctx, test.FakeClusterID)
+	require.NoError(t, err)
+	assert.EqualExportedValues(t, cluster, gotCluster)
+}
+
+func Test_fakeClusterClient_ListClusters(t *testing.T) {
+	fake := fakeconnect.New()
+	client := New(fake)
+	ctx := context.Background()
+
+	_, err := client.ListClusters(ctx, nil)
+	require.NoError(t, err)
+
+	cluster := test.FakeCluster()
+	fake.Clusters[test.FakeClusterID] = cluster
+
+	clusters, err := client.ListClusters(ctx, nil)
+	require.NoError(t, err)
+	assert.EqualExportedValues(t, []*clusterpb.Cluster{cluster}, clusters)
+}
+
+func Test_fakeClusterClient_UpdateCluster(t *testing.T) {
+	fake := fakeconnect.New()
+	client := New(fake)
+	ctx := context.Background()
+
+	cluster := test.FakeCluster()
+
+	_, err := client.UpdateCluster(ctx, cluster)
+	require.Error(t, err)
+
+	fake.TrustZones[test.FakeTrustZoneID] = test.FakeTrustZone()
+	fake.Clusters[test.FakeClusterID] = cluster
+
+	cluster = clone(cluster)
+	cluster.Name = test.PtrOf("new-cluster-name")
+	updatedCluster, err := client.UpdateCluster(ctx, cluster)
+	require.NoError(t, err)
+	assert.EqualExportedValues(t, cluster, updatedCluster)
+	assert.EqualExportedValues(t, cluster, fake.Clusters[test.FakeClusterID])
+}

--- a/pkg/connect/client/fake/client/fakeclient.go
+++ b/pkg/connect/client/fake/client/fakeclient.go
@@ -1,0 +1,42 @@
+// Copyright 2025 Cofide Limited.
+// SPDX-License-Identifier: Apache-2.0
+
+package fake
+
+import (
+	"github.com/cofide/cofide-api-sdk/pkg/connect/client"
+	agentv1alpha1 "github.com/cofide/cofide-api-sdk/pkg/connect/client/agent/v1alpha1"
+	fakeagentv1alpha1 "github.com/cofide/cofide-api-sdk/pkg/connect/client/agent/v1alpha1/fake"
+	clusterv1alpha1 "github.com/cofide/cofide-api-sdk/pkg/connect/client/cluster/v1alpha1"
+	fakeclusterv1alpha1 "github.com/cofide/cofide-api-sdk/pkg/connect/client/cluster/v1alpha1/fake"
+	fakeconnect "github.com/cofide/cofide-api-sdk/pkg/connect/client/fake/connect"
+	trustzonev1alpha1 "github.com/cofide/cofide-api-sdk/pkg/connect/client/trustzone/v1alpha1"
+	faketrustzonev1alpha1 "github.com/cofide/cofide-api-sdk/pkg/connect/client/trustzone/v1alpha1/fake"
+)
+
+type fakeClientSet struct {
+	trustZoneV1Alpha1 trustzonev1alpha1.TrustZoneClient
+	clusterV1Alpha1   clusterv1alpha1.ClusterClient
+	agentV1Alpha1     agentv1alpha1.AgentClient
+}
+
+// New instantiates a new ClientSet that fakes communication with a Connect API.
+func New(fake *fakeconnect.FakeConnect) client.ClientSet {
+	return &fakeClientSet{
+		trustZoneV1Alpha1: faketrustzonev1alpha1.New(fake),
+		clusterV1Alpha1:   fakeclusterv1alpha1.New(fake),
+		agentV1Alpha1:     fakeagentv1alpha1.New(fake),
+	}
+}
+
+func (c *fakeClientSet) TrustZoneV1Alpha1() trustzonev1alpha1.TrustZoneClient {
+	return c.trustZoneV1Alpha1
+}
+
+func (c *fakeClientSet) ClusterV1Alpha1() clusterv1alpha1.ClusterClient {
+	return c.clusterV1Alpha1
+}
+
+func (c *fakeClientSet) AgentV1Alpha1() agentv1alpha1.AgentClient {
+	return c.agentV1Alpha1
+}

--- a/pkg/connect/client/fake/client/fakeclient_test.go
+++ b/pkg/connect/client/fake/client/fakeclient_test.go
@@ -1,0 +1,18 @@
+// Copyright 2025 Cofide Limited.
+// SPDX-License-Identifier: Apache-2.0
+
+package fake
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFakeClientSet(t *testing.T) {
+	client := New(nil)
+	require.NotNil(t, client)
+	require.NotNil(t, client.TrustZoneV1Alpha1())
+	require.NotNil(t, client.ClusterV1Alpha1())
+	require.NotNil(t, client.AgentV1Alpha1())
+}

--- a/pkg/connect/client/fake/connect/fakeconnect.go
+++ b/pkg/connect/client/fake/connect/fakeconnect.go
@@ -1,0 +1,65 @@
+package fakeconnect
+
+import (
+	"sync"
+
+	agentpb "github.com/cofide/cofide-api-sdk/gen/go/proto/agent/v1alpha1"
+	clusterpb "github.com/cofide/cofide-api-sdk/gen/go/proto/cluster/v1alpha1"
+	federatedservicepb "github.com/cofide/cofide-api-sdk/gen/go/proto/federated_service/v1alpha1"
+	trustzonepb "github.com/cofide/cofide-api-sdk/gen/go/proto/trust_zone/v1alpha1"
+	"github.com/spiffe/spire-api-sdk/proto/spire/api/types"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// FakeConnect implements the state for a fake Connect service.
+type FakeConnect struct {
+	Mu                sync.Mutex
+	TrustZones        map[string]*trustzonepb.TrustZone
+	TrustZoneBundles  map[string]*types.Bundle
+	Clusters          map[string]*clusterpb.Cluster
+	Agents            map[string]*agentpb.Agent
+	AgentJoinTokens   map[string]map[string]string
+	AgentStatus       map[string]*agentpb.AgentStatus
+	FederatedServices map[string]*federatedservicepb.FederatedService
+}
+
+func New() *FakeConnect {
+	return &FakeConnect{
+		TrustZones:        make(map[string]*trustzonepb.TrustZone),
+		TrustZoneBundles:  make(map[string]*types.Bundle),
+		Clusters:          make(map[string]*clusterpb.Cluster),
+		Agents:            make(map[string]*agentpb.Agent),
+		AgentJoinTokens:   make(map[string]map[string]string),
+		AgentStatus:       make(map[string]*agentpb.AgentStatus),
+		FederatedServices: make(map[string]*federatedservicepb.FederatedService),
+	}
+}
+
+func (f *FakeConnect) ValidateTrustZone(trustZoneID string) error {
+	if _, ok := f.TrustZones[trustZoneID]; !ok {
+		return status.Error(codes.InvalidArgument, "invalid trust zone")
+	}
+	return nil
+}
+
+func (f *FakeConnect) ValidateCluster(clusterID string) error {
+	if _, ok := f.Clusters[clusterID]; !ok {
+		return status.Error(codes.InvalidArgument, "invalid cluster")
+	}
+	return nil
+}
+
+func (f *FakeConnect) ValidateAgent(agentID string) error {
+	if _, ok := f.Agents[agentID]; !ok {
+		return status.Error(codes.InvalidArgument, "invalid agent")
+	}
+	return nil
+}
+
+func (f *FakeConnect) ValidateFederatedService(federatedServiceID string) error {
+	if _, ok := f.FederatedServices[federatedServiceID]; !ok {
+		return status.Error(codes.InvalidArgument, "invalid federated service")
+	}
+	return nil
+}

--- a/pkg/connect/client/test/fakes.go
+++ b/pkg/connect/client/test/fakes.go
@@ -1,0 +1,62 @@
+// Copyright 2025 Cofide Limited.
+// SPDX-License-Identifier: Apache-2.0
+
+package test
+
+import (
+	agentpb "github.com/cofide/cofide-api-sdk/gen/go/proto/agent/v1alpha1"
+	clusterpb "github.com/cofide/cofide-api-sdk/gen/go/proto/cluster/v1alpha1"
+	federatedservicepb "github.com/cofide/cofide-api-sdk/gen/go/proto/federated_service/v1alpha1"
+	trustzonepb "github.com/cofide/cofide-api-sdk/gen/go/proto/trust_zone/v1alpha1"
+	"github.com/spiffe/spire-api-sdk/proto/spire/api/types"
+)
+
+const (
+	FakeTrustZoneID   = "fake-tz-id"
+	FakeTrustZoneName = "fake-tz-name"
+	FakeTrustDomain   = "fake.trust.domain"
+
+	FakeClusterID   = "fake-cluster-id"
+	FakeClusterName = "fake-cluster-name"
+
+	FakeAgentToken = "fake-agent-token"
+	FakeAgentID    = "fake-agent-id"
+
+	FakeFSID   = "fake-fs-id"
+	FakeFSName = "fake-fs-name"
+)
+
+func FakeTrustZone() *trustzonepb.TrustZone {
+	return &trustzonepb.TrustZone{
+		Id:          PtrOf(FakeTrustZoneID),
+		Name:        FakeTrustZoneName,
+		TrustDomain: FakeTrustDomain,
+	}
+}
+
+func FakeCluster() *clusterpb.Cluster {
+	return &clusterpb.Cluster{
+		Id:          PtrOf(FakeClusterID),
+		Name:        PtrOf(FakeClusterName),
+		TrustZoneId: PtrOf(FakeTrustZoneID),
+	}
+}
+
+func FakeAgent() *agentpb.Agent {
+	return &agentpb.Agent{
+		Id:          PtrOf(FakeAgentID),
+		ClusterId:   PtrOf(FakeClusterID),
+		TrustZoneId: PtrOf(FakeTrustZoneID),
+	}
+}
+
+func FakeFederatedService() *federatedservicepb.FederatedService {
+	return &federatedservicepb.FederatedService{
+		Id:   FakeFSID,
+		Name: FakeFSName,
+	}
+}
+
+func FakeBundle() *types.Bundle {
+	return &types.Bundle{TrustDomain: FakeTrustDomain}
+}

--- a/pkg/connect/client/trustzone/v1alpha1/fake/fake.go
+++ b/pkg/connect/client/trustzone/v1alpha1/fake/fake.go
@@ -1,0 +1,137 @@
+// Copyright 2025 Cofide Limited.
+// SPDX-License-Identifier: Apache-2.0
+
+package fake
+
+import (
+	"context"
+
+	agentpb "github.com/cofide/cofide-api-sdk/gen/go/proto/agent/v1alpha1"
+	clusterpb "github.com/cofide/cofide-api-sdk/gen/go/proto/cluster/v1alpha1"
+	trustzonesvcpb "github.com/cofide/cofide-api-sdk/gen/go/proto/connect/trust_zone_service/v1alpha1"
+	trustzonepb "github.com/cofide/cofide-api-sdk/gen/go/proto/trust_zone/v1alpha1"
+	fakeconnect "github.com/cofide/cofide-api-sdk/pkg/connect/client/fake/connect"
+	trustzonev1alpha1 "github.com/cofide/cofide-api-sdk/pkg/connect/client/trustzone/v1alpha1"
+	"github.com/google/uuid"
+	"github.com/spiffe/spire-api-sdk/proto/spire/api/types"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
+)
+
+type fakeTrustZoneClient struct {
+	fake *fakeconnect.FakeConnect
+}
+
+// New instantiates a new TrustZoneClient for communication with a fake Connect API.
+func New(fake *fakeconnect.FakeConnect) trustzonev1alpha1.TrustZoneClient {
+	return &fakeTrustZoneClient{
+		fake: fake,
+	}
+}
+
+func (c *fakeTrustZoneClient) CreateTrustZone(ctx context.Context, trustZone *trustzonepb.TrustZone) (*trustzonepb.TrustZone, error) {
+	c.fake.Mu.Lock()
+	defer c.fake.Mu.Unlock()
+
+	id := uuid.New().String()
+	trustZone = clone(trustZone)
+	trustZone.Id = &id
+	c.fake.TrustZones[trustZone.GetId()] = trustZone
+	return clone(trustZone), nil
+}
+
+func (c *fakeTrustZoneClient) GetTrustZone(ctx context.Context, trustZoneID string) (*trustzonepb.TrustZone, error) {
+	c.fake.Mu.Lock()
+	defer c.fake.Mu.Unlock()
+
+	trustZone, ok := c.fake.TrustZones[trustZoneID]
+	if !ok {
+		return nil, status.Error(codes.NotFound, "")
+	}
+	return clone(trustZone), nil
+}
+
+func (c *fakeTrustZoneClient) ListTrustZones(ctx context.Context, filter *trustzonesvcpb.ListTrustZonesRequest_Filter) ([]*trustzonepb.TrustZone, error) {
+	c.fake.Mu.Lock()
+	defer c.fake.Mu.Unlock()
+
+	trustZones := []*trustzonepb.TrustZone{}
+	for _, trustZone := range c.fake.TrustZones {
+		if trustZoneMatches(trustZone, filter) {
+			trustZones = append(trustZones, clone(trustZone))
+		}
+	}
+	return trustZones, nil
+}
+
+func trustZoneMatches(trustZone *trustzonepb.TrustZone, filter *trustzonesvcpb.ListTrustZonesRequest_Filter) bool {
+	if filter == nil {
+		return true
+	}
+	if filter.Name != nil && trustZone.GetName() != *filter.Name {
+		return false
+	}
+	if filter.OrgId != nil && trustZone.GetOrgId() != *filter.OrgId {
+		return false
+	}
+	if filter.TrustDomain != nil && trustZone.GetTrustDomain() != *filter.TrustDomain {
+		return false
+	}
+	return true
+}
+
+// DEPRECATED: Agent join token creation moved to AgentService.CreateAgentJoinToken.
+// Cluster creation to be moved to ClusterService.CreateCluster.
+func (c *fakeTrustZoneClient) RegisterCluster(ctx context.Context, trustZoneID string, cluster *clusterpb.Cluster) (string, error) {
+	c.fake.Mu.Lock()
+	defer c.fake.Mu.Unlock()
+
+	if _, ok := c.fake.TrustZones[trustZoneID]; !ok {
+		return "", status.Error(codes.InvalidArgument, "")
+	}
+	cluster = cloneCluster(cluster)
+	id := uuid.New().String()
+	cluster.Id = &id
+	cluster.TrustZoneId = &trustZoneID
+	c.fake.Clusters[id] = cluster
+	if c.fake.AgentJoinTokens[trustZoneID] == nil {
+		c.fake.AgentJoinTokens[trustZoneID] = make(map[string]string)
+	}
+	token := uuid.New().String()
+	c.fake.AgentJoinTokens[trustZoneID][cluster.GetId()] = token
+	return token, nil
+}
+
+func (c *fakeTrustZoneClient) RegisterAgent(ctx context.Context, agent *trustzonesvcpb.Agent, token string, bundle *types.Bundle) (string, error) {
+	c.fake.Mu.Lock()
+	defer c.fake.Mu.Unlock()
+
+	if _, ok := c.fake.TrustZones[agent.TrustZoneId]; !ok {
+		return "", status.Error(codes.InvalidArgument, "invalid trust zone")
+	}
+	if _, ok := c.fake.Clusters[agent.ClusterId]; !ok {
+		return "", status.Error(codes.InvalidArgument, "invalid cluster")
+	}
+	id := uuid.New().String()
+	newAgent := agentpb.Agent{
+		Id:          &id,
+		ClusterId:   &agent.ClusterId,
+		TrustZoneId: &agent.TrustZoneId,
+	}
+	c.fake.Agents[id] = &newAgent
+	c.fake.TrustZoneBundles[agent.GetTrustZoneId()] = cloneBundle(bundle)
+	return id, nil
+}
+
+func clone(trustZone *trustzonepb.TrustZone) *trustzonepb.TrustZone {
+	return proto.Clone(trustZone).(*trustzonepb.TrustZone)
+}
+
+func cloneCluster(cluster *clusterpb.Cluster) *clusterpb.Cluster {
+	return proto.Clone(cluster).(*clusterpb.Cluster)
+}
+
+func cloneBundle(bundle *types.Bundle) *types.Bundle {
+	return proto.Clone(bundle).(*types.Bundle)
+}

--- a/pkg/connect/client/trustzone/v1alpha1/fake/fake_test.go
+++ b/pkg/connect/client/trustzone/v1alpha1/fake/fake_test.go
@@ -1,0 +1,116 @@
+// Copyright 2025 Cofide Limited.
+// SPDX-License-Identifier: Apache-2.0
+
+package fake
+
+import (
+	"context"
+	"testing"
+
+	trustzonesvcpb "github.com/cofide/cofide-api-sdk/gen/go/proto/connect/trust_zone_service/v1alpha1"
+	trustzonepb "github.com/cofide/cofide-api-sdk/gen/go/proto/trust_zone/v1alpha1"
+	fakeconnect "github.com/cofide/cofide-api-sdk/pkg/connect/client/fake/connect"
+	"github.com/cofide/cofide-api-sdk/pkg/connect/client/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_fakeTrustZoneClient_CreateTrustZone(t *testing.T) {
+	fake := fakeconnect.New()
+	client := New(fake)
+	ctx := context.Background()
+
+	trustZone := test.FakeTrustZone()
+
+	createdTrustZone, err := client.CreateTrustZone(ctx, trustZone)
+	require.NoError(t, err)
+	trustZone.Id = createdTrustZone.Id
+	assert.EqualExportedValues(t, trustZone, createdTrustZone)
+	assert.EqualExportedValues(t, trustZone, fake.TrustZones[*createdTrustZone.Id])
+}
+
+func Test_fakeTrustZoneClient_GetTrustZone(t *testing.T) {
+	fake := fakeconnect.New()
+	client := New(fake)
+	ctx := context.Background()
+
+	trustZone := test.FakeTrustZone()
+
+	_, err := client.GetTrustZone(ctx, test.FakeTrustZoneID)
+	require.Error(t, err)
+
+	fake.TrustZones[test.FakeTrustZoneID] = test.FakeTrustZone()
+
+	gotTrustZone, err := client.GetTrustZone(ctx, test.FakeTrustZoneID)
+	require.NoError(t, err)
+	assert.EqualExportedValues(t, trustZone, gotTrustZone)
+	assert.EqualExportedValues(t, trustZone, fake.TrustZones[test.FakeTrustZoneID])
+}
+
+func Test_fakeTrustZoneClient_ListTrustZones(t *testing.T) {
+	fake := fakeconnect.New()
+	client := New(fake)
+	ctx := context.Background()
+
+	trustZone := test.FakeTrustZone()
+
+	trustZones, err := client.ListTrustZones(ctx, nil)
+	require.NoError(t, err)
+	assert.EqualExportedValues(t, []*trustzonepb.TrustZone{}, trustZones)
+
+	fake.TrustZones[test.FakeTrustZoneID] = test.FakeTrustZone()
+
+	trustZones, err = client.ListTrustZones(ctx, nil)
+	require.NoError(t, err)
+	assert.EqualExportedValues(t, []*trustzonepb.TrustZone{trustZone}, trustZones)
+}
+
+func Test_fakeTrustZoneClient_RegisterCluster(t *testing.T) {
+	fake := fakeconnect.New()
+	client := New(fake)
+	ctx := context.Background()
+
+	trustZone := test.FakeTrustZone()
+	cluster := test.FakeCluster()
+
+	_, err := client.RegisterCluster(ctx, test.FakeTrustZoneID, cluster)
+	require.Error(t, err)
+
+	fake.TrustZones[test.FakeTrustZoneID] = trustZone
+
+	agentToken, err := client.RegisterCluster(ctx, test.FakeTrustZoneID, cluster)
+	require.NoError(t, err)
+	for clusterID := range fake.Clusters {
+		cluster.Id = &clusterID
+	}
+	assert.EqualExportedValues(t, cluster, fake.Clusters[cluster.GetId()])
+	assert.Equal(t, fake.AgentJoinTokens[test.FakeTrustZoneID][cluster.GetId()], agentToken)
+}
+
+func Test_fakeTrustZoneClient_RegisterAgent(t *testing.T) {
+	fake := fakeconnect.New()
+	client := New(fake)
+	ctx := context.Background()
+
+	agent := fakeAgent()
+
+	_, err := client.RegisterAgent(ctx, agent, test.FakeAgentToken, test.FakeBundle())
+	require.Error(t, err)
+
+	fake.TrustZones[test.FakeTrustZoneID] = test.FakeTrustZone()
+	fake.Clusters[test.FakeClusterID] = test.FakeCluster()
+
+	agentID, err := client.RegisterAgent(ctx, agent, test.FakeAgentToken, test.FakeBundle())
+	require.NoError(t, err)
+	expectedAgent := test.FakeAgent()
+	expectedAgent.Id = &agentID
+	assert.EqualExportedValues(t, expectedAgent, fake.Agents[agentID])
+}
+
+func fakeAgent() *trustzonesvcpb.Agent {
+	return &trustzonesvcpb.Agent{
+		AgentId:     test.FakeAgentID,
+		ClusterId:   test.FakeClusterID,
+		TrustZoneId: test.FakeTrustZoneID,
+	}
+}


### PR DESCRIPTION
This allows users of this module to inject fake clients into their test
code, avoiding the use of real gRPC servers.
