### PR TITLE
feat: move attestation policy bindings and federations from TrustZone to Config

### DIFF
--- a/proto/config/v1alpha1/config.proto
+++ b/proto/config/v1alpha1/config.proto
@@ -6,8 +6,10 @@ syntax = "proto3";
 package proto.config.v1alpha1;
 
 import "google/protobuf/struct.proto";
+import "proto/ap_binding/v1alpha1/ap_binding.proto";
 import "proto/attestation_policy/v1alpha1/attestation_policy.proto";
 import "proto/cluster/v1alpha1/cluster.proto";
+import "proto/federation/v1alpha1/federation.proto";
 import "proto/plugins/v1alpha1/plugins.proto";
 import "proto/trust_zone/v1alpha1/trust_zone.proto";
 
@@ -19,4 +21,6 @@ message Config {
   repeated proto.attestation_policy.v1alpha1.AttestationPolicy attestation_policies = 3;
   map<string, google.protobuf.Struct> plugin_config = 4;
   optional proto.plugins.v1alpha1.Plugins plugins = 5;
+  repeated proto.federation.v1alpha1.Federation federations = 6;
+  repeated proto.ap_binding.v1alpha1.APBinding ap_bindings = 7;
 }

--- a/proto/trust_zone/v1alpha1/trust_zone.proto
+++ b/proto/trust_zone/v1alpha1/trust_zone.proto
@@ -16,8 +16,8 @@ message TrustZone {
   string trust_domain = 2;
   optional string bundle_endpoint_url = 3;
   optional spire.api.types.Bundle bundle = 4;
-  repeated proto.federation.v1alpha1.Federation federations = 5;
-  repeated proto.ap_binding.v1alpha1.APBinding attestation_policies = 6;
+  repeated proto.federation.v1alpha1.Federation federations = 5 [deprecated = true];
+  repeated proto.ap_binding.v1alpha1.APBinding attestation_policies = 6 [deprecated = true];
   optional string jwt_issuer = 7;
   optional BundleEndpointProfile bundle_endpoint_profile = 8;
   optional string id = 9;


### PR DESCRIPTION
The TrustZone fields have been deprecated and will be removed at a later
date.

Fixes: #60
