### PR TITLE
fix: Update `APBindingClient` name

### DIFF
--- a/pkg/connect/client/clientset.go
+++ b/pkg/connect/client/clientset.go
@@ -20,7 +20,7 @@ type ClientSet interface {
 	ClusterV1Alpha1() clusterv1alpha1.ClusterClient
 	AgentV1Alpha1() agentv1alpha1.AgentClient
 	AttestationPolicyV1Alpha1() attestationpolicyv1alpha1.AttestationPolicyClient
-	APBindingV1Alhpa1() apbindingv1alpha1.APBindingClient
+	APBindingV1Alpha1() apbindingv1alpha1.APBindingClient
 	FederationV1Alpha1() federationV1Alpha1.FederationClient
 }
 
@@ -61,7 +61,7 @@ func (c *clientSet) AttestationPolicyV1Alpha1() attestationpolicyv1alpha1.Attest
 	return c.attestationPolicyV1Alpha1
 }
 
-func (c *clientSet) APBindingV1Alhpa1() apbindingv1alpha1.APBindingClient {
+func (c *clientSet) APBindingV1Alpha1() apbindingv1alpha1.APBindingClient {
 	return c.apBindingV1Alpha1
 }
 

--- a/pkg/connect/client/clientset_test.go
+++ b/pkg/connect/client/clientset_test.go
@@ -16,6 +16,6 @@ func TestClientSet(t *testing.T) {
 	require.NotNil(t, client.ClusterV1Alpha1())
 	require.NotNil(t, client.AgentV1Alpha1())
 	require.NotNil(t, client.AttestationPolicyV1Alpha1())
-	require.NotNil(t, client.APBindingV1Alhpa1())
+	require.NotNil(t, client.APBindingV1Alpha1())
 	require.NotNil(t, client.FederationV1Alpha1())
 }

--- a/pkg/connect/client/fake/client/fakeclient.go
+++ b/pkg/connect/client/fake/client/fakeclient.go
@@ -57,7 +57,7 @@ func (c *fakeClientSet) AttestationPolicyV1Alpha1() attestationpolicyv1alpha1.At
 	return c.attestationPolicyV1Alpha1
 }
 
-func (c *fakeClientSet) APBindingV1Alhpa1() apbindingv1alpha1.APBindingClient {
+func (c *fakeClientSet) APBindingV1Alpha1() apbindingv1alpha1.APBindingClient {
 	return c.apBindingV1Alpha1
 }
 


### PR DESCRIPTION
### Summary
- This PR adds a small fix to update the `APBindingClient` name.