### PR TITLE
fix: bump go to 1.23.10 to address GO-2025-3750

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cofide/cofide-api-sdk
 
-go 1.23.8
+go 1.23.10
 
 require (
 	connectrpc.com/connect v1.18.1


### PR DESCRIPTION
Inconsistent handling of O_CREATE|O_EXCL on Unix and Windows in os in
syscall

https://pkg.go.dev/vuln/GO-2025-3750
