### PR TITLE
chore: Remove UpdateManagedTrustZoneBundle from TrustZoneClient

### DIFF
--- a/pkg/connect/client/trustzone/v1alpha1/fake/fake_test.go
+++ b/pkg/connect/client/trustzone/v1alpha1/fake/fake_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/cofide/cofide-api-sdk/pkg/connect/client/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"google.golang.org/grpc/metadata"
 )
 
 func Test_fakeTrustZoneClient_CreateTrustZone(t *testing.T) {
@@ -126,40 +125,18 @@ func Test_fakeTrustZoneClient_UpdateTrustZoneBundle(t *testing.T) {
 	ctx := context.Background()
 
 	fakeBundle := test.FakeBundle()
-
-	err := client.UpdateTrustZoneBundle(ctx, fakeBundle)
-	require.Error(t, err)
-
-	md := metadata.MD{"agent-id": []string{test.FakeAgentID}}
-	ctx = metadata.NewIncomingContext(ctx, md)
-
-	err = client.UpdateTrustZoneBundle(ctx, fakeBundle)
+	err := client.UpdateTrustZoneBundle(ctx, test.FakeTrustZoneID, fakeBundle)
 	require.Error(t, err)
 
 	fake.TrustZones[test.FakeTrustZoneID] = test.FakeTrustZone()
 
-	err = client.UpdateTrustZoneBundle(ctx, fakeBundle)
-	require.Error(t, err)
-
-	fake.Agents[test.FakeAgentID] = test.FakeAgent()
-
-	err = client.UpdateTrustZoneBundle(ctx, fakeBundle)
+	err = client.UpdateTrustZoneBundle(ctx, test.FakeTrustZoneID, fakeBundle)
 	require.NoError(t, err)
 	assert.Equal(t, fake.TrustZoneBundles[test.FakeTrustZoneID], fakeBundle)
-}
+	assert.NotSame(t, fake.TrustZoneBundles[test.FakeTrustZoneID], fakeBundle)
 
-func Test_fakeTrustZoneClient_UpdateManagedTrustZoneBundle(t *testing.T) {
-	fake := fakeconnect.New()
-	client := New(fake)
-	ctx := context.Background()
-
-	fakeBundle := test.FakeBundle()
-	err := client.UpdateManagedTrustZoneBundle(ctx, test.FakeTrustZoneID, fakeBundle)
-	require.Error(t, err)
-
-	fake.TrustZones[test.FakeTrustZoneID] = test.FakeTrustZone()
-
-	err = client.UpdateManagedTrustZoneBundle(ctx, test.FakeTrustZoneID, fakeBundle)
+	fakeBundle.SequenceNumber = 42
+	err = client.UpdateTrustZoneBundle(ctx, test.FakeTrustZoneID, fakeBundle)
 	require.NoError(t, err)
 	assert.Equal(t, fake.TrustZoneBundles[test.FakeTrustZoneID], fakeBundle)
 }

--- a/pkg/connect/client/trustzone/v1alpha1/trustzone.go
+++ b/pkg/connect/client/trustzone/v1alpha1/trustzone.go
@@ -21,8 +21,7 @@ type TrustZoneClient interface {
 	UpdateTrustZone(ctx context.Context, trustZone *trustzonepb.TrustZone) (*trustzonepb.TrustZone, error)
 	RegisterAgent(ctx context.Context, agent *trustzonesvcpb.Agent, token string, bundle *types.Bundle) (string, error)
 	RegisterTrustZoneServer(ctx context.Context, server *trustzonesvcpb.TrustZoneServer, bundle *types.Bundle) error
-	UpdateTrustZoneBundle(ctx context.Context, bundle *types.Bundle) error
-	UpdateManagedTrustZoneBundle(ctx context.Context, trustZoneID string, bundle *types.Bundle) error
+	UpdateTrustZoneBundle(ctx context.Context, trustZoneID string, bundle *types.Bundle) error
 }
 
 type trustZoneClient struct {
@@ -109,23 +108,11 @@ func (c *trustZoneClient) RegisterTrustZoneServer(ctx context.Context, server *t
 	return err
 }
 
-func (c *trustZoneClient) UpdateTrustZoneBundle(ctx context.Context, bundle *types.Bundle) error {
-	trustZoneBundleUpdateRequest := &trustzonesvcpb.UpdateTrustZoneBundleRequest{
-		Bundle: bundle,
-	}
-	return c.updateTrustZoneBundle(ctx, trustZoneBundleUpdateRequest)
-}
-
-func (c *trustZoneClient) UpdateManagedTrustZoneBundle(ctx context.Context, trustZoneID string, bundle *types.Bundle) error {
-	trustZoneBundleUpdateRequest := &trustzonesvcpb.UpdateTrustZoneBundleRequest{
+func (c *trustZoneClient) UpdateTrustZoneBundle(ctx context.Context, trustZoneID string, bundle *types.Bundle) error {
+	_, err := c.trustZoneClient.UpdateTrustZoneBundle(ctx, &trustzonesvcpb.UpdateTrustZoneBundleRequest{
 		Bundle:      bundle,
 		TrustZoneId: trustZoneID,
-	}
-	return c.updateTrustZoneBundle(ctx, trustZoneBundleUpdateRequest)
-}
-
-func (c *trustZoneClient) updateTrustZoneBundle(ctx context.Context, req *trustzonesvcpb.UpdateTrustZoneBundleRequest) error {
-	_, err := c.trustZoneClient.UpdateTrustZoneBundle(ctx, req)
+	})
 	if err != nil {
 		return err
 	}

--- a/pkg/connect/client/trustzone/v1alpha1/trustzone_test.go
+++ b/pkg/connect/client/trustzone/v1alpha1/trustzone_test.go
@@ -105,10 +105,7 @@ func TestTrustZoneClient(t *testing.T) {
 	require.NoError(t, err)
 
 	fakeBundle := &types.Bundle{TrustDomain: fakeTrustDomain}
-	err = client.UpdateTrustZoneBundle(ctx, fakeBundle)
-	require.NoError(t, err)
-
-	err = client.UpdateManagedTrustZoneBundle(ctx, fakeTrustZoneID, fakeBundle)
+	err = client.UpdateTrustZoneBundle(ctx, fakeTrustZoneID, fakeBundle)
 	require.NoError(t, err)
 }
 


### PR DESCRIPTION
UpdateTrustZoneBundle now accepts a trust zone ID, and can be used for
both the local and managed trust zones.
