### PR TITLE
Remove a bogus DEPRECATED comment

### DIFF
--- a/gen/go/proto/connect/agent_service/v1alpha1/agent_service_grpc.pb.go
+++ b/gen/go/proto/connect/agent_service/v1alpha1/agent_service_grpc.pb.go
@@ -39,7 +39,6 @@ type AgentServiceClient interface {
 	CreateAgentJoinToken(ctx context.Context, in *CreateAgentJoinTokenRequest, opts ...grpc.CallOption) (*CreateAgentJoinTokenResponse, error)
 	UpdateTrustZoneBundle(ctx context.Context, in *UpdateTrustZoneBundleRequest, opts ...grpc.CallOption) (*UpdateTrustZoneBundleResponse, error)
 	UpdateAgentStatus(ctx context.Context, in *UpdateAgentStatusRequest, opts ...grpc.CallOption) (*UpdateAgentStatusResponse, error)
-	// DEPRECATED: Federated service RPCs will move to a separate service.
 	RegisterFederatedService(ctx context.Context, in *RegisterFederatedServiceRequest, opts ...grpc.CallOption) (*RegisterFederatedServiceResponse, error)
 	DeregisterFederatedService(ctx context.Context, in *DeregisterFederatedServiceRequest, opts ...grpc.CallOption) (*DeregisterFederatedServiceResponse, error)
 	UpdateFederatedService(ctx context.Context, in *UpdateFederatedServiceRequest, opts ...grpc.CallOption) (*UpdateFederatedServiceResponse, error)
@@ -142,7 +141,6 @@ type AgentServiceServer interface {
 	CreateAgentJoinToken(context.Context, *CreateAgentJoinTokenRequest) (*CreateAgentJoinTokenResponse, error)
 	UpdateTrustZoneBundle(context.Context, *UpdateTrustZoneBundleRequest) (*UpdateTrustZoneBundleResponse, error)
 	UpdateAgentStatus(context.Context, *UpdateAgentStatusRequest) (*UpdateAgentStatusResponse, error)
-	// DEPRECATED: Federated service RPCs will move to a separate service.
 	RegisterFederatedService(context.Context, *RegisterFederatedServiceRequest) (*RegisterFederatedServiceResponse, error)
 	DeregisterFederatedService(context.Context, *DeregisterFederatedServiceRequest) (*DeregisterFederatedServiceResponse, error)
 	UpdateFederatedService(context.Context, *UpdateFederatedServiceRequest) (*UpdateFederatedServiceResponse, error)

--- a/gen/go/proto/connect/agent_service/v1alpha1/v1alpha1connect/agent_service.connect.go
+++ b/gen/go/proto/connect/agent_service/v1alpha1/v1alpha1connect/agent_service.connect.go
@@ -67,7 +67,6 @@ type AgentServiceClient interface {
 	CreateAgentJoinToken(context.Context, *connect.Request[v1alpha1.CreateAgentJoinTokenRequest]) (*connect.Response[v1alpha1.CreateAgentJoinTokenResponse], error)
 	UpdateTrustZoneBundle(context.Context, *connect.Request[v1alpha1.UpdateTrustZoneBundleRequest]) (*connect.Response[v1alpha1.UpdateTrustZoneBundleResponse], error)
 	UpdateAgentStatus(context.Context, *connect.Request[v1alpha1.UpdateAgentStatusRequest]) (*connect.Response[v1alpha1.UpdateAgentStatusResponse], error)
-	// DEPRECATED: Federated service RPCs will move to a separate service.
 	RegisterFederatedService(context.Context, *connect.Request[v1alpha1.RegisterFederatedServiceRequest]) (*connect.Response[v1alpha1.RegisterFederatedServiceResponse], error)
 	DeregisterFederatedService(context.Context, *connect.Request[v1alpha1.DeregisterFederatedServiceRequest]) (*connect.Response[v1alpha1.DeregisterFederatedServiceResponse], error)
 	UpdateFederatedService(context.Context, *connect.Request[v1alpha1.UpdateFederatedServiceRequest]) (*connect.Response[v1alpha1.UpdateFederatedServiceResponse], error)
@@ -202,7 +201,6 @@ type AgentServiceHandler interface {
 	CreateAgentJoinToken(context.Context, *connect.Request[v1alpha1.CreateAgentJoinTokenRequest]) (*connect.Response[v1alpha1.CreateAgentJoinTokenResponse], error)
 	UpdateTrustZoneBundle(context.Context, *connect.Request[v1alpha1.UpdateTrustZoneBundleRequest]) (*connect.Response[v1alpha1.UpdateTrustZoneBundleResponse], error)
 	UpdateAgentStatus(context.Context, *connect.Request[v1alpha1.UpdateAgentStatusRequest]) (*connect.Response[v1alpha1.UpdateAgentStatusResponse], error)
-	// DEPRECATED: Federated service RPCs will move to a separate service.
 	RegisterFederatedService(context.Context, *connect.Request[v1alpha1.RegisterFederatedServiceRequest]) (*connect.Response[v1alpha1.RegisterFederatedServiceResponse], error)
 	DeregisterFederatedService(context.Context, *connect.Request[v1alpha1.DeregisterFederatedServiceRequest]) (*connect.Response[v1alpha1.DeregisterFederatedServiceResponse], error)
 	UpdateFederatedService(context.Context, *connect.Request[v1alpha1.UpdateFederatedServiceRequest]) (*connect.Response[v1alpha1.UpdateFederatedServiceResponse], error)

--- a/gen/ts/proto/connect/agent_service/v1alpha1/agent_service_pb.ts
+++ b/gen/ts/proto/connect/agent_service/v1alpha1/agent_service_pb.ts
@@ -324,8 +324,6 @@ export const AgentService: GenService<{
     output: typeof UpdateAgentStatusResponseSchema;
   },
   /**
-   * DEPRECATED: Federated service RPCs will move to a separate service.
-   *
    * @generated from rpc proto.connect.agent_service.v1alpha1.AgentService.RegisterFederatedService
    */
   registerFederatedService: {

--- a/proto/connect/agent_service/v1alpha1/agent_service.proto
+++ b/proto/connect/agent_service/v1alpha1/agent_service.proto
@@ -17,7 +17,6 @@ service AgentService {
   rpc UpdateTrustZoneBundle(UpdateTrustZoneBundleRequest) returns (UpdateTrustZoneBundleResponse) {}
   rpc UpdateAgentStatus(UpdateAgentStatusRequest) returns (UpdateAgentStatusResponse) {}
 
-  // DEPRECATED: Federated service RPCs will move to a separate service.
   rpc RegisterFederatedService(RegisterFederatedServiceRequest) returns (RegisterFederatedServiceResponse) {}
   rpc DeregisterFederatedService(DeregisterFederatedServiceRequest) returns (DeregisterFederatedServiceResponse) {}
   rpc UpdateFederatedService(UpdateFederatedServiceRequest) returns (UpdateFederatedServiceResponse) {}


### PR DESCRIPTION
As discussed in #110, it is not deprecated because there is currently no alternative.