### PR TITLE
Add generic pagination struct

### DIFF
--- a/pkg/connect/client/audit/v1alpha1/audit.go
+++ b/pkg/connect/client/audit/v1alpha1/audit.go
@@ -9,12 +9,13 @@ import (
 	auditpb "github.com/cofide/cofide-api-sdk/gen/go/proto/audit/v1alpha1"
 	auditsvcpb "github.com/cofide/cofide-api-sdk/gen/go/proto/connect/audit_service/v1alpha1"
 	paginationpb "github.com/cofide/cofide-api-sdk/gen/go/proto/pagination/v1alpha1"
+	"github.com/cofide/cofide-api-sdk/pkg/connect/client/pagination"
 	"google.golang.org/grpc"
 )
 
 // AuditClient is an interface for a gRPC client for the v1alpha1 version of the Connect AuditService.
 type AuditClient interface {
-	ListEvents(ctx context.Context, filter *auditsvcpb.ListEventsRequest_Filter, pageSize int32, pageToken string) ([]*auditpb.Event, string, error)
+	ListEvents(ctx context.Context, filter *auditsvcpb.ListEventsRequest_Filter, requestPagination pagination.Pagination) ([]*auditpb.Event, pagination.Pagination, error)
 }
 
 type auditClient struct {
@@ -28,17 +29,17 @@ func New(conn grpc.ClientConnInterface) AuditClient {
 	}
 }
 
-func (c *auditClient) ListEvents(ctx context.Context, filter *auditsvcpb.ListEventsRequest_Filter, pageSize int32, pageToken string) ([]*auditpb.Event, string, error) {
+func (c *auditClient) ListEvents(ctx context.Context, filter *auditsvcpb.ListEventsRequest_Filter, requestPagination pagination.Pagination) ([]*auditpb.Event, pagination.Pagination, error) {
 	resp, err := c.auditClient.ListEvents(ctx, &auditsvcpb.ListEventsRequest{
 		Filter: filter,
 		Pagination: &paginationpb.PageRequest{
-			PageSize:  pageSize,
-			PageToken: pageToken,
+			PageSize:  requestPagination.PageSize,
+			PageToken: requestPagination.Token,
 		},
 	})
 	if err != nil {
-		return nil, "", err
+		return nil, pagination.Pagination{}, err
 	}
 
-	return resp.Events, resp.Pagination.GetNextPageToken(), nil
+	return resp.GetEvents(), pagination.Pagination{PageSize: requestPagination.PageSize, Token: resp.GetPagination().GetNextPageToken()}, nil
 }

--- a/pkg/connect/client/audit/v1alpha1/audit_test.go
+++ b/pkg/connect/client/audit/v1alpha1/audit_test.go
@@ -9,6 +9,7 @@ import (
 
 	auditpb "github.com/cofide/cofide-api-sdk/gen/go/proto/audit/v1alpha1"
 	auditsvcpb "github.com/cofide/cofide-api-sdk/gen/go/proto/connect/audit_service/v1alpha1"
+	"github.com/cofide/cofide-api-sdk/pkg/connect/client/pagination"
 	"github.com/cofide/cofide-api-sdk/pkg/connect/client/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -24,7 +25,7 @@ func TestAuditClient_Unimplemented(t *testing.T) {
 	conn := server.CreateClientConn()
 	client := New(conn)
 
-	events, _, err := client.ListEvents(t.Context(), nil, 100, "")
+	events, _, err := client.ListEvents(t.Context(), nil, pagination.Pagination{PageSize: 100})
 	test.RequireUnimplemented(t, err)
 	assert.Nil(t, events)
 }
@@ -38,7 +39,7 @@ func TestAuditClient(t *testing.T) {
 	client := New(conn)
 
 	filter := &auditsvcpb.ListEventsRequest_Filter{Entities: []*auditsvcpb.ListEventsRequest_Filter_Entity{{Type: auditpb.EntityType_ENTITY_TYPE_ORGANIZATION}}}
-	events, _, err := client.ListEvents(t.Context(), filter, 100, "")
+	events, _, err := client.ListEvents(t.Context(), filter, pagination.Pagination{PageSize: 100})
 	require.NoError(t, err)
 	assert.EqualExportedValues(t, []*auditpb.Event{{Id: "mock-id"}}, events)
 }

--- a/pkg/connect/client/audit/v1alpha1/fake/fake.go
+++ b/pkg/connect/client/audit/v1alpha1/fake/fake.go
@@ -11,6 +11,7 @@ import (
 	auditsvcpb "github.com/cofide/cofide-api-sdk/gen/go/proto/connect/audit_service/v1alpha1"
 	auditv1alpha1 "github.com/cofide/cofide-api-sdk/pkg/connect/client/audit/v1alpha1"
 	fakeconnect "github.com/cofide/cofide-api-sdk/pkg/connect/client/fake/connect"
+	"github.com/cofide/cofide-api-sdk/pkg/connect/client/pagination"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -25,7 +26,7 @@ func New(fake *fakeconnect.FakeConnect) auditv1alpha1.AuditClient {
 	}
 }
 
-func (c *fakeAuditClient) ListEvents(ctx context.Context, filter *auditsvcpb.ListEventsRequest_Filter, pageSize int32, pageToken string) ([]*auditpb.Event, string, error) {
+func (c *fakeAuditClient) ListEvents(ctx context.Context, filter *auditsvcpb.ListEventsRequest_Filter, requestPagination pagination.Pagination) ([]*auditpb.Event, pagination.Pagination, error) {
 	c.fake.Mu.Lock()
 	defer c.fake.Mu.Unlock()
 
@@ -35,7 +36,7 @@ func (c *fakeAuditClient) ListEvents(ctx context.Context, filter *auditsvcpb.Lis
 			events = append(events, clone(event))
 		}
 	}
-	return events, "", nil
+	return events, pagination.Pagination{PageSize: requestPagination.PageSize}, nil
 }
 
 func (c *fakeAuditClient) eventMatches(event *auditpb.Event, filter *auditsvcpb.ListEventsRequest_Filter) bool {

--- a/pkg/connect/client/audit/v1alpha1/fake/fake_test.go
+++ b/pkg/connect/client/audit/v1alpha1/fake/fake_test.go
@@ -13,6 +13,7 @@ import (
 	auditsvcpb "github.com/cofide/cofide-api-sdk/gen/go/proto/connect/audit_service/v1alpha1"
 	trustzonepb "github.com/cofide/cofide-api-sdk/gen/go/proto/trust_zone/v1alpha1"
 	fakeconnect "github.com/cofide/cofide-api-sdk/pkg/connect/client/fake/connect"
+	"github.com/cofide/cofide-api-sdk/pkg/connect/client/pagination"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -22,7 +23,7 @@ func Test_fakeAuditClient_ListEvents(t *testing.T) {
 	fake := fakeconnect.New()
 	client := New(fake)
 
-	events, _, err := client.ListEvents(t.Context(), nil, 100, "")
+	events, _, err := client.ListEvents(t.Context(), nil, pagination.Pagination{PageSize: 100})
 	require.NoError(t, err)
 	assert.Empty(t, events)
 
@@ -50,7 +51,7 @@ func Test_fakeAuditClient_ListEvents(t *testing.T) {
 		Outcome:  auditpb.Outcome_OUTCOME_SUCCESS,
 	}
 
-	events, _, err = client.ListEvents(t.Context(), nil, 100, "")
+	events, _, err = client.ListEvents(t.Context(), nil, pagination.Pagination{PageSize: 100})
 	require.NoError(t, err)
 	assert.EqualExportedValues(t, slices.Collect(maps.Values(fake.AuditEvents)), events)
 }
@@ -63,7 +64,7 @@ func Test_fakeAuditClient_ListEvents_filterMatchLinkless(t *testing.T) {
 	fake.AuditEvents["event-2"] = &auditpb.Event{Id: "event-2"}
 
 	// match_linkless alone matches only linkless events
-	events, _, err := client.ListEvents(t.Context(), &auditsvcpb.ListEventsRequest_Filter{MatchLinkless: true}, 100, "")
+	events, _, err := client.ListEvents(t.Context(), &auditsvcpb.ListEventsRequest_Filter{MatchLinkless: true}, pagination.Pagination{PageSize: 100})
 	require.NoError(t, err)
 	require.Len(t, events, 1)
 	assert.Equal(t, "event-2", events[0].GetId())
@@ -72,7 +73,7 @@ func Test_fakeAuditClient_ListEvents_filterMatchLinkless(t *testing.T) {
 	events, _, err = client.ListEvents(t.Context(), &auditsvcpb.ListEventsRequest_Filter{
 		Entities:      []*auditsvcpb.ListEventsRequest_Filter_Entity{{Type: auditpb.EntityType_ENTITY_TYPE_ORGANIZATION}},
 		MatchLinkless: true,
-	}, 100, "")
+	}, pagination.Pagination{PageSize: 100})
 	require.NoError(t, err)
 	assert.Len(t, events, 2)
 }
@@ -84,12 +85,12 @@ func Test_fakeAuditClient_ListEvents_filterActors(t *testing.T) {
 	fake.AuditEvents["event-1"] = &auditpb.Event{Id: "event-1", Actor: "user-1"}
 	fake.AuditEvents["event-2"] = &auditpb.Event{Id: "event-2", Actor: "user-2"}
 
-	events, _, err := client.ListEvents(t.Context(), &auditsvcpb.ListEventsRequest_Filter{Actors: []string{"user-1"}}, 100, "")
+	events, _, err := client.ListEvents(t.Context(), &auditsvcpb.ListEventsRequest_Filter{Actors: []string{"user-1"}}, pagination.Pagination{PageSize: 100})
 	require.NoError(t, err)
 	require.Len(t, events, 1)
 	assert.Equal(t, "event-1", events[0].GetId())
 
-	events, _, err = client.ListEvents(t.Context(), &auditsvcpb.ListEventsRequest_Filter{Actors: []string{"user-1", "user-2"}}, 100, "")
+	events, _, err = client.ListEvents(t.Context(), &auditsvcpb.ListEventsRequest_Filter{Actors: []string{"user-1", "user-2"}}, pagination.Pagination{PageSize: 100})
 	require.NoError(t, err)
 	assert.Len(t, events, 2)
 }
@@ -101,12 +102,12 @@ func Test_fakeAuditClient_ListEvents_filterSourceIPs(t *testing.T) {
 	fake.AuditEvents["event-1"] = &auditpb.Event{Id: "event-1", SourceIp: "1.2.3.4"}
 	fake.AuditEvents["event-2"] = &auditpb.Event{Id: "event-2", SourceIp: "5.6.7.8"}
 
-	events, _, err := client.ListEvents(t.Context(), &auditsvcpb.ListEventsRequest_Filter{SourceIps: []string{"1.2.3.4"}}, 100, "")
+	events, _, err := client.ListEvents(t.Context(), &auditsvcpb.ListEventsRequest_Filter{SourceIps: []string{"1.2.3.4"}}, pagination.Pagination{PageSize: 100})
 	require.NoError(t, err)
 	require.Len(t, events, 1)
 	assert.Equal(t, "event-1", events[0].GetId())
 
-	events, _, err = client.ListEvents(t.Context(), &auditsvcpb.ListEventsRequest_Filter{SourceIps: []string{"1.2.3.4", "5.6.7.8"}}, 100, "")
+	events, _, err = client.ListEvents(t.Context(), &auditsvcpb.ListEventsRequest_Filter{SourceIps: []string{"1.2.3.4", "5.6.7.8"}}, pagination.Pagination{PageSize: 100})
 	require.NoError(t, err)
 	assert.Len(t, events, 2)
 }
@@ -118,12 +119,12 @@ func Test_fakeAuditClient_ListEvents_filterOutcomes(t *testing.T) {
 	fake.AuditEvents["event-1"] = &auditpb.Event{Id: "event-1", Outcome: auditpb.Outcome_OUTCOME_SUCCESS}
 	fake.AuditEvents["event-2"] = &auditpb.Event{Id: "event-2", Outcome: auditpb.Outcome_OUTCOME_DENIED}
 
-	events, _, err := client.ListEvents(t.Context(), &auditsvcpb.ListEventsRequest_Filter{Outcomes: []auditpb.Outcome{auditpb.Outcome_OUTCOME_SUCCESS}}, 100, "")
+	events, _, err := client.ListEvents(t.Context(), &auditsvcpb.ListEventsRequest_Filter{Outcomes: []auditpb.Outcome{auditpb.Outcome_OUTCOME_SUCCESS}}, pagination.Pagination{PageSize: 100})
 	require.NoError(t, err)
 	require.Len(t, events, 1)
 	assert.Equal(t, "event-1", events[0].GetId())
 
-	events, _, err = client.ListEvents(t.Context(), &auditsvcpb.ListEventsRequest_Filter{Outcomes: []auditpb.Outcome{auditpb.Outcome_OUTCOME_SUCCESS, auditpb.Outcome_OUTCOME_DENIED}}, 100, "")
+	events, _, err = client.ListEvents(t.Context(), &auditsvcpb.ListEventsRequest_Filter{Outcomes: []auditpb.Outcome{auditpb.Outcome_OUTCOME_SUCCESS, auditpb.Outcome_OUTCOME_DENIED}}, pagination.Pagination{PageSize: 100})
 	require.NoError(t, err)
 	assert.Len(t, events, 2)
 }
@@ -139,7 +140,7 @@ func Test_fakeAuditClient_ListEvents_filterExcludeEventTypes(t *testing.T) {
 		Exclude: &auditsvcpb.ListEventsRequest_Filter_Exclude{
 			EventTypes: []auditpb.EventType{auditpb.EventType_EVENT_TYPE_WORKLOAD_OBSERVATION},
 		},
-	}, 100, "")
+	}, pagination.Pagination{PageSize: 100})
 	require.NoError(t, err)
 	require.Len(t, events, 1)
 	assert.Equal(t, "event-1", events[0].GetId())
@@ -157,7 +158,7 @@ func Test_fakeAuditClient_ListEvents_filterExcludeEntities(t *testing.T) {
 		Exclude: &auditsvcpb.ListEventsRequest_Filter_Exclude{
 			Entities: []*auditsvcpb.ListEventsRequest_Filter_Entity{{Id: "tz-1"}},
 		},
-	}, 100, "")
+	}, pagination.Pagination{PageSize: 100})
 	require.NoError(t, err)
 	require.Len(t, events, 1)
 	assert.Equal(t, "event-2", events[0].GetId())
@@ -167,7 +168,7 @@ func Test_fakeAuditClient_ListEvents_filterExcludeEntities(t *testing.T) {
 		Exclude: &auditsvcpb.ListEventsRequest_Filter_Exclude{
 			Entities: []*auditsvcpb.ListEventsRequest_Filter_Entity{{Type: auditpb.EntityType_ENTITY_TYPE_TRUST_ZONE}},
 		},
-	}, 100, "")
+	}, pagination.Pagination{PageSize: 100})
 	require.NoError(t, err)
 	assert.Empty(t, events)
 }
@@ -181,7 +182,7 @@ func Test_fakeAuditClient_ListEvents_filterExcludeActors(t *testing.T) {
 
 	events, _, err := client.ListEvents(t.Context(), &auditsvcpb.ListEventsRequest_Filter{
 		Exclude: &auditsvcpb.ListEventsRequest_Filter_Exclude{Actors: []string{"user-1"}},
-	}, 100, "")
+	}, pagination.Pagination{PageSize: 100})
 	require.NoError(t, err)
 	require.Len(t, events, 1)
 	assert.Equal(t, "event-2", events[0].GetId())
@@ -196,7 +197,7 @@ func Test_fakeAuditClient_ListEvents_filterExcludeSourceIPs(t *testing.T) {
 
 	events, _, err := client.ListEvents(t.Context(), &auditsvcpb.ListEventsRequest_Filter{
 		Exclude: &auditsvcpb.ListEventsRequest_Filter_Exclude{SourceIps: []string{"1.2.3.4"}},
-	}, 100, "")
+	}, pagination.Pagination{PageSize: 100})
 	require.NoError(t, err)
 	require.Len(t, events, 1)
 	assert.Equal(t, "event-2", events[0].GetId())
@@ -211,7 +212,7 @@ func Test_fakeAuditClient_ListEvents_filterExcludeOutcomes(t *testing.T) {
 
 	events, _, err := client.ListEvents(t.Context(), &auditsvcpb.ListEventsRequest_Filter{
 		Exclude: &auditsvcpb.ListEventsRequest_Filter_Exclude{Outcomes: []auditpb.Outcome{auditpb.Outcome_OUTCOME_DENIED}},
-	}, 100, "")
+	}, pagination.Pagination{PageSize: 100})
 	require.NoError(t, err)
 	require.Len(t, events, 1)
 	assert.Equal(t, "event-1", events[0].GetId())
@@ -243,7 +244,7 @@ func Test_fakeAuditClient_ListEvents_filterIncludeAndExclude(t *testing.T) {
 		Exclude: &auditsvcpb.ListEventsRequest_Filter_Exclude{
 			EventTypes: []auditpb.EventType{auditpb.EventType_EVENT_TYPE_WORKLOAD_OBSERVATION},
 		},
-	}, 100, "")
+	}, pagination.Pagination{PageSize: 100})
 	require.NoError(t, err)
 	require.Len(t, events, 1)
 	assert.Equal(t, "event-1", events[0].GetId())

--- a/pkg/connect/client/pagination/pagination.go
+++ b/pkg/connect/client/pagination/pagination.go
@@ -1,0 +1,6 @@
+package pagination
+
+type Pagination struct {
+	Token    string
+	PageSize int32
+}


### PR DESCRIPTION
Follow-up to https://github.com/cofide/cofide-api-sdk/pull/197#discussion_r3129875698

Previously pagination (letting server default page size) looked like
```go
events, token, err := client.ListEvents(ctx, nil, 0, "")
if err != nil {
    return nil, err
}
for token != "" {
    newEvents, token, err = client.ListEvents(ctx, nil, 0, token)
    if err != nil {
        return nil, err
    }
    events = append(events, newEvents)
}
return events, nil
```

Now it would be
```go
events, pagination, err := client.ListEvents(ctx, nil, pagination.Pagination{})
if err != nil {
    return nil, err
}
for pagination.Token != "" {
    newEvents, token, err = client.ListEvents(ctx, nil, pagination)
    if err != nil {
        return nil, err
    }
    events = append(events, newEvents)
}
return events, nil
```