### PR TITLE
Upgrade required minimum Go version to 1.25.11

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cofide/cofide-api-sdk
 
-go 1.25.9
+go 1.25.11
 
 // NOTE: Take care to avoid forcing unnecessary upgrades on consumers when
 // updating dependencies.


### PR DESCRIPTION
This should resolve the govulncheck errors currently showing on every PR https://github.com/cofide/cofide-api-sdk/actions/runs/26914365733/job/79400342838?pr=207

This does bump the minimum Go version for consumers, but only patch versions so impact there should be minimal.

If we're going to avoid bumping the minimum Go version when not strictly required for functionality then an alternative tool to govulncheck is probably worth looking at - since findings can't be suppressed (see https://github.com/golang/go/issues/61211) it's currently noisy and often being ignored.