### PR TITLE
Resolve GO-2026-5856 by updating required patch version of Go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cofide/cofide-api-sdk
 
-go 1.25.11
+go 1.25.12
 
 // NOTE: Take care to avoid forcing unnecessary upgrades on consumers when
 // updating dependencies.


### PR DESCRIPTION
Resolves GO-2026-5856. Details of report below.
```
Vulnerability #1: GO-2026-5856
    Invoking Encrypted Client Hello privacy leak in crypto/tls
  More info: https://pkg.go.dev/vuln/GO-2026-5856
  Standard library
    Found in: crypto/tls@go1.25.11
    Fixed in: crypto/tls@go1.25.12
    Example traces found:
      #1: gen/go/proto/connect/datastore_service/v1alpha1/datastore_service.pb.go:1645:86: v1alpha1.file_proto_connect_datastore_service_v1alpha1_datastore_service_proto_rawDescGZIP calls sync.Once.Do, which eventually calls tls.Conn.Handshake
      #2: pkg/connect/client/trustzone/v1alpha1/fake/fake.go:116:16: fake.fakeTrustZoneClient.RegisterAgent calls uuid.New, which eventually calls tls.Conn.Read
      #3: pkg/connect/client/test/utils.go:20:14: test.RequireUnimplemented calls assert.Equal, which eventually calls tls.Conn.Write


```