### PR TITLE
Add PublishWorkloads to WorkloadClient

### DIFF
--- a/pkg/connect/client/audit/v1alpha1/audit.go
+++ b/pkg/connect/client/audit/v1alpha1/audit.go
@@ -30,11 +30,6 @@ func New(conn grpc.ClientConnInterface) AuditClient {
 	}
 }
 
-func (c *auditClient) RecordExchange(ctx context.Context, req *auditsvcpb.RecordExchangeRequest) error {
-	_, err := c.auditClient.RecordExchange(ctx, req)
-	return err
-}
-
 func (c *auditClient) ListEvents(ctx context.Context, filter *auditsvcpb.ListEventsRequest_Filter, requestPagination pagination.Pagination) ([]*auditpb.Event, pagination.Pagination, error) {
 	resp, err := c.auditClient.ListEvents(ctx, &auditsvcpb.ListEventsRequest{
 		Filter: filter,
@@ -48,4 +43,9 @@ func (c *auditClient) ListEvents(ctx context.Context, filter *auditsvcpb.ListEve
 	}
 
 	return resp.GetEvents(), pagination.Pagination{PageSize: requestPagination.PageSize, Token: resp.GetPagination().GetNextPageToken()}, nil
+}
+
+func (c *auditClient) RecordExchange(ctx context.Context, req *auditsvcpb.RecordExchangeRequest) error {
+	_, err := c.auditClient.RecordExchange(ctx, req)
+	return err
 }

--- a/pkg/connect/client/workload/v1alpha1/fake/fake.go
+++ b/pkg/connect/client/workload/v1alpha1/fake/fake.go
@@ -39,6 +39,31 @@ func (c *fakeWorkloadClient) ListWorkloads(ctx context.Context, filter *workload
 	return workloads, nil
 }
 
+func (c *fakeWorkloadClient) PublishWorkloads(ctx context.Context) (workloadv1alpha1.WorkloadsStream, error) {
+	return &fakeWorkloadsStream{fake: c.fake}, nil
+}
+
+type fakeWorkloadsStream struct {
+	fake *fakeconnect.FakeConnect
+}
+
+func (s *fakeWorkloadsStream) Send(workloads []*workloadpb.Workload) error {
+	s.fake.Mu.Lock()
+	defer s.fake.Mu.Unlock()
+
+	for _, workload := range workloads {
+		if workload == nil {
+			continue
+		}
+		s.fake.Workloads[workload.GetId()] = proto.Clone(workload).(*workloadpb.Workload)
+	}
+	return nil
+}
+
+func (s *fakeWorkloadsStream) Close() error {
+	return nil
+}
+
 func (c *fakeWorkloadClient) ListWorkloadEvents(ctx context.Context, filter *workloadsvcpb.ListWorkloadEventsRequest_Filter, requestPagination pagination.Pagination) ([]*workloadpb.WorkloadEvent, pagination.Pagination, error) {
 	c.fake.Mu.Lock()
 	defer c.fake.Mu.Unlock()

--- a/pkg/connect/client/workload/v1alpha1/fake/fake_test.go
+++ b/pkg/connect/client/workload/v1alpha1/fake/fake_test.go
@@ -36,6 +36,39 @@ func Test_fakeWorkloadClient_ListWorkloads(t *testing.T) {
 	assert.EqualExportedValues(t, []*workloadpb.Workload{workload}, workloads)
 }
 
+func Test_fakeWorkloadsStream_Send_upsertsByID(t *testing.T) {
+	fake := fakeconnect.New()
+	client := New(fake)
+
+	stream, err := client.PublishWorkloads(t.Context())
+	require.NoError(t, err)
+
+	workload := &workloadpb.Workload{Id: "workload-1", OrgId: "org-1"}
+	require.NoError(t, stream.Send([]*workloadpb.Workload{workload}))
+
+	assert.EqualExportedValues(t, workload, fake.Workloads["workload-1"])
+
+	updated := &workloadpb.Workload{Id: "workload-1", OrgId: "org-1", Deleted: true}
+	require.NoError(t, stream.Send([]*workloadpb.Workload{updated}))
+
+	assert.Len(t, fake.Workloads, 1)
+	assert.EqualExportedValues(t, updated, fake.Workloads["workload-1"])
+}
+
+func Test_fakeWorkloadsStream_Send_skipsNilWorkloads(t *testing.T) {
+	fake := fakeconnect.New()
+	client := New(fake)
+
+	stream, err := client.PublishWorkloads(t.Context())
+	require.NoError(t, err)
+
+	workload := &workloadpb.Workload{Id: "workload-1"}
+	require.NoError(t, stream.Send([]*workloadpb.Workload{workload, nil}))
+
+	assert.Len(t, fake.Workloads, 1)
+	assert.EqualExportedValues(t, workload, fake.Workloads["workload-1"])
+}
+
 func Test_fakeWorkloadClient_ListWorkloadEvents_filterObservedTimeRange(t *testing.T) {
 	fake := fakeconnect.New()
 	client := New(fake)
@@ -146,39 +179,6 @@ func Test_fakeWorkloadClient_ListWorkloadEvents_filterEventTypes(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.EqualExportedValues(t, []*workloadpb.WorkloadEvent{workloadAttestationFailed, identityDelivered, noIdentity}, events)
-}
-
-func Test_fakeWorkloadsStream_Send_upsertsByID(t *testing.T) {
-	fake := fakeconnect.New()
-	client := New(fake)
-
-	stream, err := client.PublishWorkloads(t.Context())
-	require.NoError(t, err)
-
-	workload := &workloadpb.Workload{Id: "workload-1", OrgId: "org-1"}
-	require.NoError(t, stream.Send([]*workloadpb.Workload{workload}))
-
-	assert.EqualExportedValues(t, workload, fake.Workloads["workload-1"])
-
-	updated := &workloadpb.Workload{Id: "workload-1", OrgId: "org-1", Deleted: true}
-	require.NoError(t, stream.Send([]*workloadpb.Workload{updated}))
-
-	assert.Len(t, fake.Workloads, 1)
-	assert.EqualExportedValues(t, updated, fake.Workloads["workload-1"])
-}
-
-func Test_fakeWorkloadsStream_Send_skipsNilWorkloads(t *testing.T) {
-	fake := fakeconnect.New()
-	client := New(fake)
-
-	stream, err := client.PublishWorkloads(t.Context())
-	require.NoError(t, err)
-
-	workload := &workloadpb.Workload{Id: "workload-1"}
-	require.NoError(t, stream.Send([]*workloadpb.Workload{workload, nil}))
-
-	assert.Len(t, fake.Workloads, 1)
-	assert.EqualExportedValues(t, workload, fake.Workloads["workload-1"])
 }
 
 func Test_fakeWorkloadEventsStream_Send_skipsNilEvents(t *testing.T) {

--- a/pkg/connect/client/workload/v1alpha1/fake/fake_test.go
+++ b/pkg/connect/client/workload/v1alpha1/fake/fake_test.go
@@ -148,6 +148,39 @@ func Test_fakeWorkloadClient_ListWorkloadEvents_filterEventTypes(t *testing.T) {
 	assert.EqualExportedValues(t, []*workloadpb.WorkloadEvent{workloadAttestationFailed, identityDelivered, noIdentity}, events)
 }
 
+func Test_fakeWorkloadsStream_Send_upsertsByID(t *testing.T) {
+	fake := fakeconnect.New()
+	client := New(fake)
+
+	stream, err := client.PublishWorkloads(t.Context())
+	require.NoError(t, err)
+
+	workload := &workloadpb.Workload{Id: "workload-1", OrgId: "org-1"}
+	require.NoError(t, stream.Send([]*workloadpb.Workload{workload}))
+
+	assert.EqualExportedValues(t, workload, fake.Workloads["workload-1"])
+
+	updated := &workloadpb.Workload{Id: "workload-1", OrgId: "org-1", Deleted: true}
+	require.NoError(t, stream.Send([]*workloadpb.Workload{updated}))
+
+	assert.Len(t, fake.Workloads, 1)
+	assert.EqualExportedValues(t, updated, fake.Workloads["workload-1"])
+}
+
+func Test_fakeWorkloadsStream_Send_skipsNilWorkloads(t *testing.T) {
+	fake := fakeconnect.New()
+	client := New(fake)
+
+	stream, err := client.PublishWorkloads(t.Context())
+	require.NoError(t, err)
+
+	workload := &workloadpb.Workload{Id: "workload-1"}
+	require.NoError(t, stream.Send([]*workloadpb.Workload{workload, nil}))
+
+	assert.Len(t, fake.Workloads, 1)
+	assert.EqualExportedValues(t, workload, fake.Workloads["workload-1"])
+}
+
 func Test_fakeWorkloadEventsStream_Send_skipsNilEvents(t *testing.T) {
 	fake := fakeconnect.New()
 	client := New(fake)

--- a/pkg/connect/client/workload/v1alpha1/workload.go
+++ b/pkg/connect/client/workload/v1alpha1/workload.go
@@ -13,6 +13,13 @@ import (
 	"google.golang.org/grpc"
 )
 
+// WorkloadsStream is the write end of a PublishWorkloads client stream.
+// The caller is responsible for batching, reconnection, and calling Close when done.
+type WorkloadsStream interface {
+	Send(workloads []*workloadpb.Workload) error
+	Close() error
+}
+
 // WorkloadEventsStream is the write end of a PublishWorkloadEvents client stream.
 // The caller is responsible for batching, reconnection, and calling Close when done.
 type WorkloadEventsStream interface {
@@ -23,6 +30,7 @@ type WorkloadEventsStream interface {
 // WorkloadClient is an interface for a client for the v1alpha1 version of the Connect WorkloadService.
 type WorkloadClient interface {
 	ListWorkloads(ctx context.Context, filter *workloadsvcpb.ListWorkloadsRequest_Filter) ([]*workloadpb.Workload, error)
+	PublishWorkloads(ctx context.Context) (WorkloadsStream, error)
 	ListWorkloadEvents(ctx context.Context, filter *workloadsvcpb.ListWorkloadEventsRequest_Filter, requestPagination pagination.Pagination) ([]*workloadpb.WorkloadEvent, pagination.Pagination, error)
 	PublishWorkloadEvents(ctx context.Context) (WorkloadEventsStream, error)
 }
@@ -58,6 +66,27 @@ func (c *workloadClient) ListWorkloadEvents(ctx context.Context, filter *workloa
 		return nil, pagination.Pagination{}, err
 	}
 	return resp.GetEvents(), pagination.Pagination{PageSize: requestPagination.PageSize, Token: resp.GetPagination().GetNextPageToken()}, nil
+}
+
+func (c *workloadClient) PublishWorkloads(ctx context.Context) (WorkloadsStream, error) {
+	stream, err := c.workloadClient.PublishWorkloads(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return &workloadsStream{stream: stream}, nil
+}
+
+type workloadsStream struct {
+	stream grpc.ClientStreamingClient[workloadsvcpb.PublishWorkloadsRequest, workloadsvcpb.PublishWorkloadsResponse]
+}
+
+func (s *workloadsStream) Send(workloads []*workloadpb.Workload) error {
+	return s.stream.Send(&workloadsvcpb.PublishWorkloadsRequest{Workloads: workloads})
+}
+
+func (s *workloadsStream) Close() error {
+	_, err := s.stream.CloseAndRecv()
+	return err
 }
 
 func (c *workloadClient) PublishWorkloadEvents(ctx context.Context) (WorkloadEventsStream, error) {

--- a/pkg/connect/client/workload/v1alpha1/workload.go
+++ b/pkg/connect/client/workload/v1alpha1/workload.go
@@ -54,6 +54,14 @@ func (c *workloadClient) ListWorkloads(ctx context.Context, filter *workloadsvcp
 	return resp.Workloads, nil
 }
 
+func (c *workloadClient) PublishWorkloads(ctx context.Context) (WorkloadsStream, error) {
+	stream, err := c.workloadClient.PublishWorkloads(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return &workloadsStream{stream: stream}, nil
+}
+
 func (c *workloadClient) ListWorkloadEvents(ctx context.Context, filter *workloadsvcpb.ListWorkloadEventsRequest_Filter, requestPagination pagination.Pagination) ([]*workloadpb.WorkloadEvent, pagination.Pagination, error) {
 	resp, err := c.workloadClient.ListWorkloadEvents(ctx, &workloadsvcpb.ListWorkloadEventsRequest{
 		Filter: filter,
@@ -68,12 +76,12 @@ func (c *workloadClient) ListWorkloadEvents(ctx context.Context, filter *workloa
 	return resp.GetEvents(), pagination.Pagination{PageSize: requestPagination.PageSize, Token: resp.GetPagination().GetNextPageToken()}, nil
 }
 
-func (c *workloadClient) PublishWorkloads(ctx context.Context) (WorkloadsStream, error) {
-	stream, err := c.workloadClient.PublishWorkloads(ctx)
+func (c *workloadClient) PublishWorkloadEvents(ctx context.Context) (WorkloadEventsStream, error) {
+	stream, err := c.workloadClient.PublishWorkloadEvents(ctx)
 	if err != nil {
 		return nil, err
 	}
-	return &workloadsStream{stream: stream}, nil
+	return &workloadEventsStream{stream: stream}, nil
 }
 
 type workloadsStream struct {
@@ -87,14 +95,6 @@ func (s *workloadsStream) Send(workloads []*workloadpb.Workload) error {
 func (s *workloadsStream) Close() error {
 	_, err := s.stream.CloseAndRecv()
 	return err
-}
-
-func (c *workloadClient) PublishWorkloadEvents(ctx context.Context) (WorkloadEventsStream, error) {
-	stream, err := c.workloadClient.PublishWorkloadEvents(ctx)
-	if err != nil {
-		return nil, err
-	}
-	return &workloadEventsStream{stream: stream}, nil
 }
 
 type workloadEventsStream struct {

--- a/pkg/connect/client/workload/v1alpha1/workload_test.go
+++ b/pkg/connect/client/workload/v1alpha1/workload_test.go
@@ -75,10 +75,38 @@ func TestWorkloadClient_PublishWorkloads(t *testing.T) {
 	assert.Equal(t, "workload-3", fakeService.received[2].GetId())
 }
 
+func TestWorkloadClient_PublishWorkloadEvents(t *testing.T) {
+	fakeService := &fakeWorkloadService{}
+	server := test.NewTestServer(t)
+	workloadsvcpb.RegisterWorkloadServiceServer(server.Server, fakeService)
+	server.Serve()
+
+	conn := server.CreateClientConn()
+	client := New(conn)
+	ctx := context.Background()
+
+	stream, err := client.PublishWorkloadEvents(ctx)
+	require.NoError(t, err)
+
+	events := []*workloadpb.WorkloadEvent{
+		{Id: "event-1", OrgId: "org-1"},
+		{Id: "event-2", OrgId: "org-1"},
+	}
+	require.NoError(t, stream.Send(events))
+	require.NoError(t, stream.Send([]*workloadpb.WorkloadEvent{{Id: "event-3", OrgId: "org-1"}}))
+	require.NoError(t, stream.Close())
+
+	assert.Len(t, fakeService.receivedEvents, 3)
+	assert.Equal(t, "event-1", fakeService.receivedEvents[0].GetId())
+	assert.Equal(t, "event-2", fakeService.receivedEvents[1].GetId())
+	assert.Equal(t, "event-3", fakeService.receivedEvents[2].GetId())
+}
+
 type fakeWorkloadService struct {
 	workloadsvcpb.UnimplementedWorkloadServiceServer
 
-	received []*workloadpb.Workload
+	received       []*workloadpb.Workload
+	receivedEvents []*workloadpb.WorkloadEvent
 }
 
 func (f *fakeWorkloadService) PublishWorkloads(stream grpc.ClientStreamingServer[workloadsvcpb.PublishWorkloadsRequest, workloadsvcpb.PublishWorkloadsResponse]) error {
@@ -91,5 +119,18 @@ func (f *fakeWorkloadService) PublishWorkloads(stream grpc.ClientStreamingServer
 			return err
 		}
 		f.received = append(f.received, req.GetWorkloads()...)
+	}
+}
+
+func (f *fakeWorkloadService) PublishWorkloadEvents(stream grpc.ClientStreamingServer[workloadsvcpb.PublishWorkloadEventsRequest, workloadsvcpb.PublishWorkloadEventsResponse]) error {
+	for {
+		req, err := stream.Recv()
+		if err == io.EOF {
+			return stream.SendAndClose(&workloadsvcpb.PublishWorkloadEventsResponse{})
+		}
+		if err != nil {
+			return err
+		}
+		f.receivedEvents = append(f.receivedEvents, req.GetEvents()...)
 	}
 }

--- a/pkg/connect/client/workload/v1alpha1/workload_test.go
+++ b/pkg/connect/client/workload/v1alpha1/workload_test.go
@@ -1,0 +1,95 @@
+// Copyright 2026 Cofide Limited.
+// SPDX-License-Identifier: Apache-2.0
+
+package v1alpha1
+
+import (
+	"context"
+	"io"
+	"testing"
+
+	workloadsvcpb "github.com/cofide/cofide-api-sdk/gen/go/proto/connect/workload_service/v1alpha1"
+	workloadpb "github.com/cofide/cofide-api-sdk/gen/go/proto/workload/v1alpha1"
+	"github.com/cofide/cofide-api-sdk/pkg/connect/client/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+)
+
+func TestWorkloadClient_implementsMethods(t *testing.T) {
+	test.AssertClientImplementsService(t, &workloadClient{}, workloadsvcpb.WorkloadService_ServiceDesc)
+}
+
+// TestWorkloadClient_Unimplemented tests WorkloadClient against an unimplemented server.
+// This ensures that all errors returned are not wrapped can be converted to a gRPC Status using Status.Convert.
+func TestWorkloadClient_Unimplemented(t *testing.T) {
+	server := test.NewTestServer(t)
+	workloadsvcpb.RegisterWorkloadServiceServer(server.Server, &workloadsvcpb.UnimplementedWorkloadServiceServer{})
+	server.Serve()
+
+	conn := server.CreateClientConn()
+	client := New(conn)
+	ctx := context.Background()
+
+	workloads, err := client.ListWorkloads(ctx, nil)
+	test.RequireUnimplemented(t, err)
+	if workloads != nil {
+		t.Errorf("expected nil workloads, got %v", workloads)
+	}
+
+	stream, err := client.PublishWorkloads(ctx)
+	require.NoError(t, err)
+	_ = stream.Send([]*workloadpb.Workload{{Id: "workload-1"}})
+	test.RequireUnimplemented(t, stream.Close())
+
+	eventsStream, err := client.PublishWorkloadEvents(ctx)
+	require.NoError(t, err)
+	_ = eventsStream.Send([]*workloadpb.WorkloadEvent{{OrgId: "org-1"}})
+	test.RequireUnimplemented(t, eventsStream.Close())
+}
+
+func TestWorkloadClient_PublishWorkloads(t *testing.T) {
+	fakeService := &fakeWorkloadService{}
+	server := test.NewTestServer(t)
+	workloadsvcpb.RegisterWorkloadServiceServer(server.Server, fakeService)
+	server.Serve()
+
+	conn := server.CreateClientConn()
+	client := New(conn)
+	ctx := context.Background()
+
+	stream, err := client.PublishWorkloads(ctx)
+	require.NoError(t, err)
+
+	workloads := []*workloadpb.Workload{
+		{Id: "workload-1", OrgId: "org-1"},
+		{Id: "workload-2", OrgId: "org-1"},
+	}
+	require.NoError(t, stream.Send(workloads))
+	require.NoError(t, stream.Send([]*workloadpb.Workload{{Id: "workload-3", OrgId: "org-1"}}))
+	require.NoError(t, stream.Close())
+
+	assert.Len(t, fakeService.received, 3)
+	assert.Equal(t, "workload-1", fakeService.received[0].GetId())
+	assert.Equal(t, "workload-2", fakeService.received[1].GetId())
+	assert.Equal(t, "workload-3", fakeService.received[2].GetId())
+}
+
+type fakeWorkloadService struct {
+	workloadsvcpb.UnimplementedWorkloadServiceServer
+
+	received []*workloadpb.Workload
+}
+
+func (f *fakeWorkloadService) PublishWorkloads(stream grpc.ClientStreamingServer[workloadsvcpb.PublishWorkloadsRequest, workloadsvcpb.PublishWorkloadsResponse]) error {
+	for {
+		req, err := stream.Recv()
+		if err == io.EOF {
+			return stream.SendAndClose(&workloadsvcpb.PublishWorkloadsResponse{})
+		}
+		if err != nil {
+			return err
+		}
+		f.received = append(f.received, req.GetWorkloads()...)
+	}
+}

--- a/pkg/connect/client/workload/v1alpha1/workload_test.go
+++ b/pkg/connect/client/workload/v1alpha1/workload_test.go
@@ -9,7 +9,9 @@ import (
 	"testing"
 
 	workloadsvcpb "github.com/cofide/cofide-api-sdk/gen/go/proto/connect/workload_service/v1alpha1"
+	paginationpb "github.com/cofide/cofide-api-sdk/gen/go/proto/pagination/v1alpha1"
 	workloadpb "github.com/cofide/cofide-api-sdk/gen/go/proto/workload/v1alpha1"
+	"github.com/cofide/cofide-api-sdk/pkg/connect/client/pagination"
 	"github.com/cofide/cofide-api-sdk/pkg/connect/client/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -100,6 +102,36 @@ func TestWorkloadClient_PublishWorkloads(t *testing.T) {
 	assert.Equal(t, "workload-3", fakeService.received[2].GetId())
 }
 
+func TestWorkloadClient_ListWorkloadEvents(t *testing.T) {
+	fakeService := &fakeWorkloadService{
+		events: []*workloadpb.WorkloadEvent{
+			{Id: "event-1", OrgId: "org-1"},
+			{Id: "event-2", OrgId: "org-1"},
+		},
+		nextPageToken: "next-token",
+	}
+	server := test.NewTestServer(t)
+	workloadsvcpb.RegisterWorkloadServiceServer(server.Server, fakeService)
+	server.Serve()
+
+	conn := server.CreateClientConn()
+	client := New(conn)
+
+	filter := &workloadsvcpb.ListWorkloadEventsRequest_Filter{OrgIds: []string{"org-1"}}
+	requestPagination := pagination.Pagination{PageSize: 10, Token: "current-token"}
+	events, responsePagination, err := client.ListWorkloadEvents(t.Context(), filter, requestPagination)
+	require.NoError(t, err)
+
+	require.Len(t, events, 2)
+	assert.Equal(t, "event-1", events[0].GetId())
+	assert.Equal(t, "event-2", events[1].GetId())
+	assert.Equal(t, pagination.Pagination{PageSize: 10, Token: "next-token"}, responsePagination)
+
+	assert.Equal(t, []string{"org-1"}, fakeService.receivedEventsFilter.GetOrgIds())
+	assert.Equal(t, int32(10), fakeService.receivedEventsPagination.GetPageSize())
+	assert.Equal(t, "current-token", fakeService.receivedEventsPagination.GetPageToken())
+}
+
 func TestWorkloadClient_PublishWorkloadEvents(t *testing.T) {
 	fakeService := &fakeWorkloadService{}
 	server := test.NewTestServer(t)
@@ -133,6 +165,11 @@ type fakeWorkloadService struct {
 	workloads      []*workloadpb.Workload
 	receivedFilter *workloadsvcpb.ListWorkloadsRequest_Filter
 
+	events                   []*workloadpb.WorkloadEvent
+	nextPageToken            string
+	receivedEventsFilter     *workloadsvcpb.ListWorkloadEventsRequest_Filter
+	receivedEventsPagination *paginationpb.PageRequest
+
 	received       []*workloadpb.Workload
 	receivedEvents []*workloadpb.WorkloadEvent
 }
@@ -140,6 +177,15 @@ type fakeWorkloadService struct {
 func (f *fakeWorkloadService) ListWorkloads(ctx context.Context, req *workloadsvcpb.ListWorkloadsRequest) (*workloadsvcpb.ListWorkloadsResponse, error) {
 	f.receivedFilter = req.GetFilter()
 	return &workloadsvcpb.ListWorkloadsResponse{Workloads: f.workloads}, nil
+}
+
+func (f *fakeWorkloadService) ListWorkloadEvents(ctx context.Context, req *workloadsvcpb.ListWorkloadEventsRequest) (*workloadsvcpb.ListWorkloadEventsResponse, error) {
+	f.receivedEventsFilter = req.GetFilter()
+	f.receivedEventsPagination = req.GetPagination()
+	return &workloadsvcpb.ListWorkloadEventsResponse{
+		Events:     f.events,
+		Pagination: &paginationpb.PageResponse{NextPageToken: f.nextPageToken},
+	}, nil
 }
 
 func (f *fakeWorkloadService) PublishWorkloads(stream grpc.ClientStreamingServer[workloadsvcpb.PublishWorkloadsRequest, workloadsvcpb.PublishWorkloadsResponse]) error {

--- a/pkg/connect/client/workload/v1alpha1/workload_test.go
+++ b/pkg/connect/client/workload/v1alpha1/workload_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
+	"google.golang.org/protobuf/proto"
 )
 
 func TestWorkloadClient_implementsMethods(t *testing.T) {
@@ -46,6 +47,30 @@ func TestWorkloadClient_Unimplemented(t *testing.T) {
 	require.NoError(t, err)
 	_ = eventsStream.Send([]*workloadpb.WorkloadEvent{{OrgId: "org-1"}})
 	test.RequireUnimplemented(t, eventsStream.Close())
+}
+
+func TestWorkloadClient_ListWorkloads(t *testing.T) {
+	fakeService := &fakeWorkloadService{
+		workloads: []*workloadpb.Workload{
+			{Id: "workload-1", OrgId: "org-1"},
+			{Id: "workload-2", OrgId: "org-1"},
+		},
+	}
+	server := test.NewTestServer(t)
+	workloadsvcpb.RegisterWorkloadServiceServer(server.Server, fakeService)
+	server.Serve()
+
+	conn := server.CreateClientConn()
+	client := New(conn)
+
+	filter := &workloadsvcpb.ListWorkloadsRequest_Filter{OrgId: proto.String("org-1")}
+	workloads, err := client.ListWorkloads(t.Context(), filter)
+	require.NoError(t, err)
+
+	require.Len(t, workloads, 2)
+	assert.Equal(t, "workload-1", workloads[0].GetId())
+	assert.Equal(t, "workload-2", workloads[1].GetId())
+	assert.Equal(t, "org-1", fakeService.receivedFilter.GetOrgId())
 }
 
 func TestWorkloadClient_PublishWorkloads(t *testing.T) {
@@ -105,8 +130,16 @@ func TestWorkloadClient_PublishWorkloadEvents(t *testing.T) {
 type fakeWorkloadService struct {
 	workloadsvcpb.UnimplementedWorkloadServiceServer
 
+	workloads      []*workloadpb.Workload
+	receivedFilter *workloadsvcpb.ListWorkloadsRequest_Filter
+
 	received       []*workloadpb.Workload
 	receivedEvents []*workloadpb.WorkloadEvent
+}
+
+func (f *fakeWorkloadService) ListWorkloads(ctx context.Context, req *workloadsvcpb.ListWorkloadsRequest) (*workloadsvcpb.ListWorkloadsResponse, error) {
+	f.receivedFilter = req.GetFilter()
+	return &workloadsvcpb.ListWorkloadsResponse{Workloads: f.workloads}, nil
 }
 
 func (f *fakeWorkloadService) PublishWorkloads(stream grpc.ClientStreamingServer[workloadsvcpb.PublishWorkloadsRequest, workloadsvcpb.PublishWorkloadsResponse]) error {


### PR DESCRIPTION
Method was missing preventing using the client wrapper when calling this method.