### PR TITLE
Clarify actor when a join token is used

### DIFF
--- a/gen/go/proto/audit/v1alpha1/event.pb.go
+++ b/gen/go/proto/audit/v1alpha1/event.pb.go
@@ -392,7 +392,9 @@ type Event struct {
 	// accuracy - the data represents the state of entities at the time of the event, not their current schema.
 	Data []byte `protobuf:"bytes,6,opt,name=data,proto3" json:"data,omitempty"`
 	// Identifier of the actor that caused the event. For users this is the JWT sub claim, for workloads this is their
-	// SPIFFE ID, and for internal events not triggered by an external actor this is "system".
+	// SPIFFE ID, for internal events not triggered by an external actor this is "system", and for Cofide Agent
+	// registrations authenticated with a one-time join token this is "join-token" since the token only proves
+	// possession of a cluster-scoped credential, not a specific agent's identity.
 	Actor string `protobuf:"bytes,7,opt,name=actor,proto3" json:"actor,omitempty"`
 	// Source IP address of the request that caused the event, as observed by the Envoy sidecar proxy. Not present for
 	// internally-generated events (e.g. where actor is "system").

--- a/gen/ts/proto/audit/v1alpha1/event_pb.ts
+++ b/gen/ts/proto/audit/v1alpha1/event_pb.ts
@@ -97,7 +97,9 @@ export type Event = Message<"proto.audit.v1alpha1.Event"> & {
 
   /**
    * Identifier of the actor that caused the event. For users this is the JWT sub claim, for workloads this is their
-   * SPIFFE ID, and for internal events not triggered by an external actor this is "system".
+   * SPIFFE ID, for internal events not triggered by an external actor this is "system", and for Cofide Agent
+   * registrations authenticated with a one-time join token this is "join-token" since the token only proves
+   * possession of a cluster-scoped credential, not a specific agent's identity.
    *
    * @generated from field: string actor = 7;
    */

--- a/proto/audit/v1alpha1/event.proto
+++ b/proto/audit/v1alpha1/event.proto
@@ -113,7 +113,9 @@ message Event {
   // accuracy - the data represents the state of entities at the time of the event, not their current schema.
   bytes data = 6 [(google.api.field_behavior) = REQUIRED];
   // Identifier of the actor that caused the event. For users this is the JWT sub claim, for workloads this is their
-  // SPIFFE ID, and for internal events not triggered by an external actor this is "system".
+  // SPIFFE ID, for internal events not triggered by an external actor this is "system", and for Cofide Agent
+  // registrations authenticated with a one-time join token this is "join-token" since the token only proves
+  // possession of a cluster-scoped credential, not a specific agent's identity.
   string actor = 7 [(google.api.field_behavior) = REQUIRED];
   // Source IP address of the request that caused the event, as observed by the Envoy sidecar proxy. Not present for
   // internally-generated events (e.g. where actor is "system").


### PR DESCRIPTION
Pairs with https://github.com/cofide/cofide-connect/pull/2115

Since this comment on the proto contract defines what users can expect in the actor field, this clarifies the meaning of the new addition of "join-token".